### PR TITLE
Ajout Relative Orbit Number et Orbit Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ As you must have noted, there are two different config files, depending on the w
  which downloads the LANDSAT 8 products in latitude, longitude box around Toulouse, acquired in November 2015.
 
 - `python theia_download.py -l 'Toulouse' -a config_landsat.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-11-01 -f 2006-12-01`
- which downloads the SpotWorldHeritage products acquired by SPOT5 in 2005-2006
+
+which downloads the SpotWorldHeritage products acquired by SPOT5 in 2005-2006
  
 - `python ./theia_download.py -c SENTINEL2 -t T31TCJ -r 51 d 2017-01-01 -f 2018-01-01`
- which downloads the SENTINEL2 T31TCJ tile, with the relative Orbit Number 51, acquired in 2017.
+
+which downloads the SENTINEL2 T31TCJ tile, with the relative Orbit Number 51, acquired in 2017.
 
 
 ## Authentification 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ As you must have noted, there are two different config files, depending on the w
 
 - `python theia_download.py -l 'Toulouse' -a config_landsat.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-11-01 -f 2006-12-01`
  which downloads the SpotWorldHeritage products acquired by SPOT5 in 2005-2006
+ 
+- `python ./theia_download.py -c SENTINEL2 -t T31TCJ -r 51 d 2017-01-01 -f 2018-01-01`
+ which downloads the SENTINEL2 T31TCJ tile, with the relative Orbit Number 51, acquired in 2017.
 
-##Authentification 
+
+## Authentification 
 
 The config file  config_landsat.cfg or  config_landsat.cfg  must contain your email address and your password as in the examples provided.
 

--- a/theia_download.py
+++ b/theia_download.py
@@ -67,6 +67,8 @@ else :
                       choices=['LANDSAT5','LANDSAT7','LANDSAT8','SPOT1','SPOT2','SPOT3','SPOT4','SPOT5','SENTINEL2A','SENTINEL2B'],  help='Satellite',)
     parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',\
                       default=101,  help='Maximum cloud cover (%)',)
+    parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',\
+                      default=None, help='Relative Orbit Number',)
 
     (options, args) = parser.parse_args()
 
@@ -203,6 +205,9 @@ if options.platform!=None :
 dict_query['startDate']=start_date
 dict_query['completionDate']=end_date
 dict_query['maxRecords']=500
+if options.end_date!=None:
+    dict_query['relativeOrbitNumber']=end_date=options.relativeOrbitNumber
+    
 
 query="%s/%s/api/collections/%s/search.json?"%(config["serveur"], config["resto"],options.collection)+urllib.urlencode(dict_query)
 print query

--- a/theia_download.py
+++ b/theia_download.py
@@ -206,7 +206,7 @@ dict_query['startDate']=start_date
 dict_query['completionDate']=end_date
 dict_query['maxRecords']=500
 if options.end_date!=None:
-    dict_query['relativeOrbitNumber']=end_date=options.relativeOrbitNumber
+    dict_query['relativeOrbitNumber']=options.relativeOrbitNumber
     
 
 query="%s/%s/api/collections/%s/search.json?"%(config["serveur"], config["resto"],options.collection)+urllib.urlencode(dict_query)

--- a/theia_download.py
+++ b/theia_download.py
@@ -8,14 +8,14 @@ import urllib
 
 ###########################################################################
 class OptionParser (optparse.OptionParser):
- 
+
     def check_required (self, opt):
       option = self.get_option(opt)
- 
+
       # Assumes the option's 'default' is set to None!
       if getattr(self.values, option.dest) is None:
           self.error("%s option not supplied" % option)
- 
+
 ###########################################################################
 
 #==================
@@ -34,9 +34,9 @@ if len(sys.argv) == 1:
 else :
     usage = "usage: %prog [options] "
     parser = OptionParser(usage=usage)
-  
+
     parser.add_option("-l","--location", dest="location", action="store", type="string", \
-            help="town name (pick one which is not too frequent to avoid confusions)",default=None)		
+            help="town name (pick one which is not too frequent to avoid confusions)",default=None)
     parser.add_option("-a","--alternative_config", dest="alternative_config", action="store", type="string", \
             help="alternative configuration file",default=None)
     parser.add_option("-w","--write_dir", dest="write_dir", action="store",type="string",  \
@@ -66,14 +66,16 @@ else :
     parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',\
                       choices=['LANDSAT5','LANDSAT7','LANDSAT8','SPOT1','SPOT2','SPOT3','SPOT4','SPOT5','SENTINEL2A','SENTINEL2B'],  help='Satellite',)
     parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',\
-                      default=101,  help='Maximum cloud cover (%)',)
+                      default=101,  help='Maximum cloud cover (%)')
+    parser.add_option('-o', '--orbitNumber', type='int', action='store', dest='orbitNumber',\
+                      default=None, help='Orbit Number')
     parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',\
-                      default=None, help='Relative Orbit Number',)
+                      default=None, help='Relative Orbit Number')
 
     (options, args) = parser.parse_args()
 
 if options.tile==None:
-    if options.location==None:    
+    if options.location==None:
         if options.lat==None or options.lon==None:
             if options.latmin==None or options.lonmin==None or options.latmax==None or options.lonmax==None:
                 print "provide at least a point or  rectangle"
@@ -86,7 +88,7 @@ if options.tile==None:
             else:
                 print "please choose between point and rectangle, but not both"
                 sys.exit(-1)
-            
+
     else :
         if options.latmin==None and options.lonmin==None and options.latmax==None and options.lonmax==None and options.lat==None or options.lon==None:
             geom='location'
@@ -101,7 +103,7 @@ else :
         location='T'+options.tile
     else:
         print 'tile number much gave this format : T31TFJ'
-          
+
 if geom=='point':
     query_geom='lat=%f\&lon=%f'%(options.lat,options.lon)
     dict_query={'lat':options.lat,'lon':options.lon}
@@ -115,8 +117,8 @@ elif geom=='location':
 elif geom=='tile':
     query_geom='location=%s'%options.tile
     dict_query={'location':options.tile}
-    
-if options.start_date!=None:    
+
+if options.start_date!=None:
     start_date=options.start_date
     if options.end_date!=None:
         end_date=options.end_date
@@ -205,9 +207,14 @@ if options.platform!=None :
 dict_query['startDate']=start_date
 dict_query['completionDate']=end_date
 dict_query['maxRecords']=500
-if options.end_date!=None:
+
+
+if options.relativeOrbitNumber != None:
     dict_query['relativeOrbitNumber']=options.relativeOrbitNumber
-    
+
+if options.orbitNumber != None:
+    dict_query['orbitNumber']=options.orbitNumber
+
 
 query="%s/%s/api/collections/%s/search.json?"%(config["serveur"], config["resto"],options.collection)+urllib.urlencode(dict_query)
 print query
@@ -221,10 +228,10 @@ time.sleep(5)
 # Download
 #====================
 
-with open('search.json') as data_file:    
+with open('search.json') as data_file:
     data = json.load(data_file)
 
-for i in range(len(data["features"])):    
+for i in range(len(data["features"])):
     prod=data["features"][i]["properties"]["productIdentifier"]
     feature_id=data["features"][i]["id"]
 
@@ -242,7 +249,7 @@ for i in range(len(data["features"])):
         #download only if cloudCover below maxcloud
         if cloudCover <=options.maxcloud:
             os.system(get_product)
-        
+
 
             #check if binary product
 
@@ -258,11 +265,10 @@ for i in range(len(data["features"])):
             os.rename("%s"%tmpfile,"%s/%s.zip"%(options.write_dir,prod))
             print "product saved as : %s/%s.zip"%(options.write_dir,prod)
         else :
-            print "cloud cover too high : %s"%(cloudCover) 
+            print "cloud cover too high : %s"%(cloudCover)
     elif file_exists:
         print "%s already exists"%prod
     elif options.no_download:
         print "no download (-n) option was chosen"
 
 #os.remove('search.json')
-


### PR DESCRIPTION
Bonjour Olivier,

Je préparais ma série temporelle 2017 pour la tuile T31TCJ et j'ai remarqué qu'on ne pouvait pas spécifier d'orbite ou d'orbite relative dans le `theia_download.py`.

J'ai ajouté deux options : 
- `-r 51` pour l'orbite relative 51
- `-o 4221` pour l'orbite 4221

J'ai ajouté aussi une ligne dans le README avec un exemple du `-r`.
Si jamais tu veux intégrer la petite modification, et merci beaucoup pour ce script !

Bonne semaine,
Nicolas.