### PR TITLE
Add Platform "MULTISAT" to download only L3B-SNOW products 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,8 @@ If you need to go through a proxy, and if you have not configured your proxy var
 
 The program first fetches a token using your email address and password, and then uses it to download the products. As the token is only valid for two hours, it is advised to request only a reasonable number of products. It is necessary to make a first download from the site manually in order to validate your accound and the licence in the case of SPOTWORLDHERITAGE.
 
+## Alternatives
+
+The EODAG tool has an interface to download data from Theia, PEPS, and many others, and it is probably much more professional code. You might give it a try.
+https://eodag.readthedocs.io/en/latest/#
+https://github.com/CS-SI/eodag

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ If you have an account at theia, you may download products using command lines l
 
  which downloads the LANDSAT 8 products in latitude, longitude box around Toulouse, acquired in November 2015.
 
-- `python theia_download.py -l 'Toulouse' -a config_landsat.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-11-01 -f 2006-12-01`
+- `python theia_download.py -l 'Toulouse' -a config_landsat.cfg -c SPOTWORLDHERITAGE -p SPOT4 -d 2005-11-01 -f 2006-12-01`
 
-which downloads the SpotWorldHeritage products acquired by SPOT5 in 2005-2006
+which downloads the SPOTWORLDHERITAGE products acquired by SPOT5 in 2005-2006
  
 - `python ./theia_download.py -c SENTINEL2 -t T31TCJ -r 51 d 2017-01-01 -f 2018-01-01`
 
@@ -75,5 +75,5 @@ The config file  config_landsat.cfg or  config_landsat.cfg  must contain your em
 
 If you need to go through a proxy, and if you have not configured your proxy variable (`export http_proxy=http://moi:secret@proxy.mycompany.fr:8050`), you may also use one of the files like config_theia_proxy.cfg or config_landsat_proxy.cfg and add your passwords in them.
 
-The program first fetches a token using your email address and password, and then uses it to download the products. As the token is only valid for two hours, it is advised to request only a reasonable number of products. It is necessary to make a first download from the site manually in order to validate your accound and the licence in the case of SpotWorldHeritage.
+The program first fetches a token using your email address and password, and then uses it to download the products. As the token is only valid for two hours, it is advised to request only a reasonable number of products. It is necessary to make a first download from the site manually in order to validate your accound and the licence in the case of SPOTWORLDHERITAGE.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simple piece of code to automatically download the products provided b
 
 This code was written thanks to the precious help of one my colleague at CNES [Jérôme Gasperi](https://www.linkedin.com/pulse/rocket-earth-your-pocket-gasperi-jerome) who developped the "rocket" interface which is used by Theia, and the mechanism to get a token. It was then adapted by Dominique Clesse for the new Muscate interface to download Sentinel-2 products.
 
-This code relies on python 2.7 **(a new python3 branch was added on the 29yh of April)** and on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](http://theia.cnes.fr/atdistrib), and you need to add it to the config file as explained in the authentification paragraph.
+This code relies on python 2.7 **(a new python3 branch was added on the 29th of April)** and on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](http://theia.cnes.fr/atdistrib), and you need to add it to the config file as explained in the authentification paragraph.
 
 ## Examples for various sensors
 If you have an account at theia, you may download products using command lines like 

--- a/README.md
+++ b/README.md
@@ -80,5 +80,7 @@ The program first fetches a token using your email address and password, and the
 ## Alternatives
 
 The EODAG tool has an interface to download data from Theia, PEPS, and many others, and it is probably much more professional code. You might give it a try.
+
 https://eodag.readthedocs.io/en/latest/#
+
 https://github.com/CS-SI/eodag

--- a/README.md
+++ b/README.md
@@ -15,13 +15,21 @@ If you have an account at theia, you may download products using command lines l
  
  - `python ./theia_download.py -l 'Toulouse' -c SENTINEL2 -a config_theia.cfg -d 2016-09-01 -f 2016-10-01 -m  50`
 
- which downloads the SENTINEL-2 products above Toulouse, acquired in September 2016 with less tha 50% cloud cover
+ which downloads the SENTINEL-2 products above Toulouse, acquired in September 2016 with less than 50% cloud cover
 
-- `python ./theia_download.py -l 'Toulouse' -c Landsat -a config_landsat.cfg -d 2016-09-01 -f 2016-10-01`
+- `python ./theia_download.py -l 'Toulouse' -c LANDSAT -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
 
- which downloads the LANDSAT-8 products above Toulouse, acquired in September 2016.
+ which downloads the LANDSAT-8 products above Toulouse, acquired in January 2019.
+ 
+ - `python ./theia_download.py -l 'Toulouse' -c Landsat -a config_theia.cfg -d 2016-09-01 -f 2016-10-01`
 
-- `python ./theia_download.py -l 'Toulouse' -c SpotWorldHeritage -a config_landsat.cfg -d 2006-01-01 -f 2007-01-01`
+ which downloads the LANDSAT-8 products, with the old MUSCATE format above Toulouse, acquired in September 2016.
+
+- `python ./theia_download.py -l 'ALSACE' -c VENUS -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
+
+ which downloads the VENUS products above ALSACE site, acquired in January 2019.
+ 
+- `python ./theia_download.py -l 'Toulouse' -c SpotWorldHeritage -a config_theia.cfg -d 2006-01-01 -f 2007-01-01`
 
  which downloads the SPOT World Heritage products above Toulouse, acquired in 2006.
 
@@ -29,7 +37,7 @@ If you have an account at theia, you may download products using command lines l
 
  which downloads the Theia snow products above Foix (Pyrenees), acquired in November 2016. The collection option is case sensitive.
 
-As you must have noted, there are two different config files, depending on the whether you are using SENTINEL2 data (config_theia.cfg) , or Landsat or Spot world Heritage data (config_landsat.cfg). This is temporary, due to the start of MUSCATE ground segment, and soon, all the products will accessed with the config_theia.cfg authentification.
+
 
 ## Other options
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ If you have an account at theia, you may download products using command lines l
 
  which downloads the VENUS products above KHUMBU site, acquired in January 2019.
 
- 
-- `python ./theia_download.py -l 'Toulouse' -c SpotWorldHeritage -a config_theia.cfg -d 2006-01-01 -f 2007-01-01`
+- `python ./theia_download.py -l 'Yaounde' -c SPOTWORLDHERITAGE -a config_theia.cfg -d 2012-01-01 -f 2013-01-01`
 
- which downloads the SPOT World Heritage products above Toulouse, acquired in 2006.
+ 
+ - `python ./theia_download.py -l 'Toulouse' -c SWH1 -a config_theia.cfg -d 2006-01-01 -f 2007-01-01`
+
+ which downloads the SPOT World Heritage products old format above Toulouse, acquired in 2006.
 
  - `python ./theia_download.py -l 'Foix' -c Snow -a config_theia.cfg -d 2016-11-01 -f 2016-12-01`
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simple piece of code to automatically download the products provided b
 
 This code was written thanks to the precious help of one my colleague at CNES [Jérôme Gasperi](https://www.linkedin.com/pulse/rocket-earth-your-pocket-gasperi-jerome) who developped the "rocket" interface which is used by Theia, and the mechanism to get a token. It was then adapted by Dominique Clesse for the new Muscate interface to download Sentinel-2 products.
 
-This code relies on python 2.7 **(a new python3 branch was added on the 29th of April)** and on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](http://theia.cnes.fr/atdistrib), and you need to add it to the config file as explained in the authentification paragraph.
+This code has been tested with python 2.7 and python 3.6. It relies on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](http://theia.cnes.fr/atdistrib), and you need to add it to the config file as explained in the authentification paragraph.
 
 ## Examples for various sensors
 If you have an account at theia, you may download products using command lines like 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ If you have an account at theia, you may download products using command lines l
 
  which downloads the VENUS products above KHUMBU site, acquired in January 2019.
 
+ - `python ./theia_download.py -s 'HECHUAN' -c VENUSVM05 -a config_theia.cfg -d 2023-03-17 -f 2023-03-18`
+
+ which downloads the latest VENUS VM05 products above HECHUAN site, acquired in March 2023.
+
 - `python ./theia_download.py -l 'Yaounde' -c SPOTWORLDHERITAGE -a config_theia.cfg -d 2012-01-01 -f 2013-01-01`
 
  

--- a/README.md
+++ b/README.md
@@ -1,92 +1,10 @@
 # theia_download
 
-This is a simple piece of code to automatically download the products provided by Theia land data center : https://theia.cnes.fr. It can download the products delivered by Theia, such as the [Sentinel-2 L2A products] (http://www.cesbio.ups-tlse.fr/multitemp/?page_id=6041), [Landsat L2A products](http://www.cesbio.ups-tlse.fr/multitemp/?page_id=3487) and the [SpotWorldHeritage L1C products](https://www.theia-land.fr/en/projects/spot-world-heritage).
+This code is not effective anymore as the MUSCATE server for THEIA has been replaced by the [Geodes](https://geodes.cnes.fr/) server. GEODES now distributes all the Earth Observation produced by CNES, and also hosts the Copernicus COllaborative ground segment, that distributes Sentinel-1 and Sentinel-2 products. 
 
-This code was written thanks to the precious help of one my colleague at CNES [Jérôme Gasperi](https://www.linkedin.com/pulse/rocket-earth-your-pocket-gasperi-jerome) who developped the "rocket" interface which is used by Theia, and the mechanism to get a token. It was then adapted by Dominique Clesse for the new Muscate interface to download Sentinel-2 products.
-
-This code has been tested with python 2.7 and python 3.6. It relies on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](https://sso.theia-land.fr/theia/register/register.xhtml), and you need to add it to the config file as explained in the authentification paragraph.
-
-## Examples for various sensors
-If you have an account at theia, you may download products using command lines like 
-
-- `python ./theia_download.py -l 'Toulouse' -c SENTINEL2 -a config_theia.cfg -d 2016-09-01 -f 2016-10-01`
-
- which downloads the SENTINEL-2 products above Toulouse, acquired in September 2016.
- 
- - `python ./theia_download.py -l 'Toulouse' -c SENTINEL2 -a config_theia.cfg -d 2016-09-01 -f 2016-10-01 -m  50`
-
- which downloads the SENTINEL-2 products above Toulouse, acquired in September 2016 with less than 50% cloud cover
-
-- `python ./theia_download.py -l 'Toulouse' -c LANDSAT -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
-
- which downloads the LANDSAT-8 products above Toulouse, acquired in January 2019.
- 
- - `python ./theia_download.py -l 'Toulouse' -c Landsat -a config_theia.cfg -d 2016-09-01 -f 2016-10-01`
-
- which downloads the LANDSAT-8 products, with the old MUSCATE format above Toulouse, acquired in September 2016.
-
-- `python ./theia_download.py -l 'France' -c VENUS -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
-
- which downloads the VENUS products from all sites in France, acquired in January 2019.
- 
- - `python ./theia_download.py -s 'KHUMBU' -c VENUS -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
-
- which downloads the VENUS products above KHUMBU site, acquired in January 2019.
-
- - `python ./theia_download.py -s 'HECHUAN' -c VENUSVM05 -a config_theia.cfg -d 2023-03-17 -f 2023-03-18`
-
- which downloads the latest VENUS VM05 products above HECHUAN site, acquired in March 2023.
-
-- `python ./theia_download.py -l 'Yaounde' -c SPOTWORLDHERITAGE -a config_theia.cfg -d 2012-01-01 -f 2013-01-01`
-
- 
- - `python ./theia_download.py -l 'Toulouse' -c SWH1 -a config_theia.cfg -d 2006-01-01 -f 2007-01-01`
-
- which downloads the SPOT World Heritage products old format above Toulouse, acquired in 2006.
-
- - `python ./theia_download.py -l 'Foix' -c Snow -a config_theia.cfg -d 2016-11-01 -f 2016-12-01`
-
- which downloads the Theia snow products above Foix (Pyrenees), acquired in November 2016. The collection option is case sensitive.
-
- - `python ./theia_download.py -t 31TGK -a config_theia.cfg -c Snow -d 2015-01-01 --snow_level L3B-SNOW`
-
- which downloads all available Level-3B Snow products (annual syntheses) of tile 31TGK.
-
-## Other options
-
-- `python ./theia_download.py -t T31TCJ -c SENTINEL2 -a config_theia.cfg -d 2016-09-01 -f 2016-10-01`
-
- which downloads the SENTINEL-2 products above tile T31TCJ, acquired in September 2016. 
-
-- `python ./theia_download.py --lon 1 --lat 43.5 -c Landsat -a config_landsat.cfg -d 2015-11-01 -f 2015-12-01`
-
- which downloads the LANDSAT 8 products above --lon 1 --lat 43.5 (~Toulouse), acquired in November 2015.
-
-- `python ./theia_download.py --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -c Landsat -a config_landsat.cfg -d 2015-11-01 -f 2015-12-01`
-
- which downloads the LANDSAT 8 products in latitude, longitude box around Toulouse, acquired in November 2015.
-
-- `python theia_download.py -l 'Toulouse' -a config_landsat.cfg -c SPOTWORLDHERITAGE -p SPOT4 -d 2005-11-01 -f 2006-12-01`
-
-which downloads the SPOTWORLDHERITAGE products acquired by SPOT5 in 2005-2006
- 
-- `python ./theia_download.py -c SENTINEL2 -t T31TCJ -r 51 d 2017-01-01 -f 2018-01-01`
-
-which downloads the SENTINEL2 T31TCJ tile, with the relative Orbit Number 51, acquired in 2017.
+GEODES uses [the STAC API(https://geodes.cnes.fr/support/api/) but also provides a [Python API mamed PyGeodes](https://cnes.github.io/pyGeodes/index.html), already functional but still in development (as of february 2025). 
 
 
-## Authentification 
 
-The config file  config_landsat.cfg or  config_landsat.cfg  must contain your email address and your password as in the examples provided.
 
-If you need to go through a proxy, and if you have not configured your proxy variable (`export http_proxy=http://moi:secret@proxy.mycompany.fr:8050`), you may also use one of the files like config_theia_proxy.cfg or config_landsat_proxy.cfg and add your passwords in them.
 
-The program first fetches a token using your email address and password, and then uses it to download the products. As the token is only valid for two hours, it is advised to request only a reasonable number of products. It is necessary to make a first download from the site manually in order to validate your accound and the licence in the case of SPOTWORLDHERITAGE.
-
-## Alternatives
-
-The EODAG tool has an interface to download data from Theia, PEPS, and many others, and it is probably much more professional code. You might give it a try.
-
-https://eodag.readthedocs.io/en/latest/#
-
-https://github.com/CS-SI/eodag

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ If you have an account at theia, you may download products using command lines l
 
  which downloads the Theia snow products above Foix (Pyrenees), acquired in November 2016. The collection option is case sensitive.
 
+ - `python ./theia_download.py -t 31TGK -a config_theia.cfg -c Snow -d 2015-01-01 --snow_level L3B-SNOW`
 
+ which downloads all available Level-3B Snow products (annual syntheses) of tile 31TGK.
 
 ## Other options
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simple piece of code to automatically download the products provided b
 
 This code was written thanks to the precious help of one my colleague at CNES [Jérôme Gasperi](https://www.linkedin.com/pulse/rocket-earth-your-pocket-gasperi-jerome) who developped the "rocket" interface which is used by Theia, and the mechanism to get a token. It was then adapted by Dominique Clesse for the new Muscate interface to download Sentinel-2 products.
 
-This code has been tested with python 2.7 and python 3.6. It relies on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](http://theia.cnes.fr/atdistrib), and you need to add it to the config file as explained in the authentification paragraph.
+This code has been tested with python 2.7 and python 3.6. It relies on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](https://sso.theia-land.fr/theia/register/register.xhtml), and you need to add it to the config file as explained in the authentification paragraph.
 
 ## Examples for various sensors
 If you have an account at theia, you may download products using command lines like 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,14 @@ If you have an account at theia, you may download products using command lines l
 
  which downloads the LANDSAT-8 products, with the old MUSCATE format above Toulouse, acquired in September 2016.
 
-- `python ./theia_download.py -l 'ALSACE' -c VENUS -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
+- `python ./theia_download.py -l 'France' -c VENUS -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
 
- which downloads the VENUS products above ALSACE site, acquired in January 2019.
+ which downloads the VENUS products from all sites in France, acquired in January 2019.
+ 
+ - `python ./theia_download.py -s 'KHUMBU' -c VENUS -a config_theia.cfg -d 2019-01-01 -f 2019-02-01`
+
+ which downloads the VENUS products above KHUMBU site, acquired in January 2019.
+
  
 - `python ./theia_download.py -l 'Toulouse' -c SpotWorldHeritage -a config_theia.cfg -d 2006-01-01 -f 2007-01-01`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This code is not effective anymore as the MUSCATE server for THEIA has been replaced by the [Geodes](https://geodes.cnes.fr/) server. GEODES now distributes all the Earth Observation produced by CNES, and also hosts the Copernicus COllaborative ground segment, that distributes Sentinel-1 and Sentinel-2 products. 
 
-GEODES uses [the STAC API(https://geodes.cnes.fr/support/api/) but also provides a [Python API mamed PyGeodes](https://cnes.github.io/pyGeodes/index.html), already functional but still in development (as of february 2025). 
+GEODES uses [the STAC API](https://geodes.cnes.fr/support/api/) but also provides a [Python API mamed PyGeodes](https://cnes.github.io/pyGeodes/index.html), already functional but still in development (as of february 2025). 
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# theia_download
+![Geodes logo](https://wpedu2.sedoo.fr/wp-content-omp/uploads/sites/50/2024/08/Logo_GEODES-bleu-fond-transparent-2048x427.png)
 
 This code is not effective anymore as the MUSCATE server for THEIA has been replaced by the [Geodes](https://geodes.cnes.fr/) server. GEODES now distributes all the Earth Observation produced by CNES, and also hosts the Copernicus COllaborative ground segment, that distributes Sentinel-1 and Sentinel-2 products. 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simple piece of code to automatically download the products provided b
 
 This code was written thanks to the precious help of one my colleague at CNES [Jérôme Gasperi](https://www.linkedin.com/pulse/rocket-earth-your-pocket-gasperi-jerome) who developped the "rocket" interface which is used by Theia, and the mechanism to get a token. It was then adapted by Dominique Clesse for the new Muscate interface to download Sentinel-2 products.
 
-This code relies on python 2.7 and on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](http://theia.cnes.fr/atdistrib), and you need to add it to the config file as explaned in the authentification paragraph.
+This code relies on python 2.7 **(a new python3 branch was added on the 29yh of April)** and on the curl utility. *Installing curl is therefore a prerequisite*. It has been developped and tested on Linux. It might work on windows, but I cannot test it. To use the code, you need to have an account and a password [at theia](http://theia.cnes.fr/atdistrib), and you need to add it to the config file as explained in the authentification paragraph.
 
 ## Examples for various sensors
 If you have an account at theia, you may download products using command lines like 

--- a/auth_theia.txt
+++ b/auth_theia.txt
@@ -1,1 +1,0 @@
-name.surname@domain.country password

--- a/config_landsat_proxy.cfg
+++ b/config_landsat_proxy.cfg
@@ -1,8 +1,0 @@
-serveur = https://theia-landsat.cnes.fr
-resto = resto
-token_type = json
-login_theia = login_theia
-password_theia = passwd_theia
-proxy = http://proxy.truc.fr:8050
-login_proxy = login_proxy
-password_proxy = passwd_proxy

--- a/config_theia_proxy.cfg
+++ b/config_theia_proxy.cfg
@@ -1,8 +1,0 @@
-serveur = https://theia.cnes.fr/atdistrib
-resto = resto2
-token_type = text
-login_theia = login_theia 
-password_theia = passwd_theia
-proxy = http://proxy.truc.fr:8050
-login_proxy = login_proxy
-password_proxy = passwd_proxy

--- a/theia_download.py
+++ b/theia_download.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: iso-8859-1 -*-
+import glob
 import json
 import time
 import os
@@ -7,8 +8,11 @@ import os.path
 import optparse
 import sys
 from datetime import date, datetime
-import urllib
-import glob
+if sys.version_info[0] == 2:
+    from urllib import urlencode
+elif sys.version_info[0] > 2:
+    from urllib.parse import urlencode
+
 
 ###########################################################################
 
@@ -34,10 +38,10 @@ def checkDate(date_string):
         day = d[2]
         dd = datetime(int(year), int(month), int(day))
     except ValueError:
-        print "Please use a valid date"
+        print("Please use a valid date")
         sys.exit(-1)
     except IndexError:
-        print "Please use yyyy-mm-dd format for dates"
+        print("Please use yyyy-mm-dd format for dates")
         sys.exit(-1)
 
 ###########################################################################
@@ -48,19 +52,22 @@ def checkDate(date_string):
 # ==================
 if len(sys.argv) == 1:
     prog = os.path.basename(sys.argv[0])
-    print '      '+sys.argv[0]+' [options]'
-    print "     Aide : ", prog, " --help"
-    print "        ou : ", prog, " -h"
-    print "example 1 : python %s -t 'T31TFJ' -a config.cfg -d 2018-07-01 -f 2018-07-31" % sys.argv[0]
-    print "example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A" % sys.argv[0]
-    print "example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[0]
-    print "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[
-        0]
-    print "example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31" % sys.argv[
-        0]
-    print "example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0]
-    print "example 7 : python %s -s 'KHUMBU' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0]
-    print "example 8 : python %s -l 'France' -c LANDSAT -a config.cfg -d 2018-01-01" % sys.argv[0]
+    print('      '+sys.argv[0]+' [options]')
+    print("     Aide : ", prog, " --help")
+    print("        ou : ", prog, " -h")
+    print("example 1 : python %s -t 'T31TFJ' -a config.cfg -d 2018-07-01 -f 2018-07-31" %
+          sys.argv[0])
+    print("example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A" %
+          sys.argv[0])
+    print("example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" %
+          sys.argv[0])
+    print("example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[
+        0])
+    print("example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31" % sys.argv[
+        0])
+    print("example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
+    print("example 7 : python %s -s 'KHUMBU' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
+    print("example 8 : python %s -l 'France' -c LANDSAT -a config.cfg -d 2018-01-01" % sys.argv[0])
     sys.exit(-1)
 else:
     usage = "usage: %prog [options] "
@@ -112,7 +119,7 @@ if options.tile == None:
     if options.location == None and options.site == None:
         if options.lat == None or options.lon == None:
             if options.latmin == None or options.lonmin == None or options.latmax == None or options.lonmax == None:
-                print "provide at least a point or  rectangle"
+                print("provide at least a point or  rectangle")
                 sys.exit(-1)
             else:
                 geom = 'rectangle'
@@ -120,7 +127,7 @@ if options.tile == None:
             if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None:
                 geom = 'point'
             else:
-                print "please choose between point and rectangle, but not both"
+                print("please choose between point and rectangle, but not both")
                 sys.exit(-1)
     else:
         if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None and options.lat == None or options.lon == None:
@@ -129,7 +136,7 @@ if options.tile == None:
             elif options.site != None:
                 geom = 'site'
         else:
-            print "please choose location/site or coordinates, but not both"
+            print("please choose location/site or coordinates, but not both")
             sys.exit(-1)
 else:
     if (options.tile.startswith('T') and len(options.tile) == 6):
@@ -140,7 +147,7 @@ else:
         tile = 'T'+options.tile
         geom = 'tile'
     else:
-        print 'tile number much gave this format : T31TFJ'
+        print('tile number much gave this format : T31TFJ')
 
 if geom == 'point':
     query_geom = 'lat=%f\&lon=%f' % (options.lat, options.lon)
@@ -175,26 +182,24 @@ if options.start_date != None:
 # ====================
 # read config
 # ====================
-try:
-    config = {}
-    f = file(options.alternative_config)
-    for line in f.readlines():
-        spliteline = line.split('=', 1)
-        if len(spliteline) == 2:
-            config[spliteline[0].strip()] = spliteline[1].strip()
-except:
-    print "error with config file opening or parsing"
-    sys.exit(-2)
+
+config = {}
+f = open(options.alternative_config)
+for line in f.readlines():
+    spliteline = line.split('=', 1)
+    if len(spliteline) == 2:
+        config[spliteline[0].strip()] = spliteline[1].strip()
+
 
 config_error = False
 cheking_keys = ["serveur", "resto", "login_theia", "password_theia", "token_type"]
-if "proxy" in config.keys():
+if "proxy" in list(config.keys()):
     cheking_keys.extend(["login_proxy", "password_proxy"])
 
 for key_name in cheking_keys:
-    if key_name not in config.keys():
+    if key_name not in list(config.keys()):
         config_error = True
-        print str("error with config file, missing key : %s" % key_name)
+        print(str("error with config file, missing key : %s" % key_name))
 if config_error:
     sys.exit(-2)
 
@@ -202,7 +207,7 @@ if config_error:
 # proxy
 # =====================
 curl_proxy = ""
-if "proxy" in config.keys():
+if "proxy" in list(config.keys()):
     curl_proxy = str('-x %s --proxy-user "%s:%s"' %
                      (config["proxy"], config["login_proxy"], config["password_proxy"]))
 
@@ -233,12 +238,12 @@ with open('token.json') as data_file:
             token = data_file.readline()
 
         else:
-            print str("error with config file, unknown token_type : %s" % token_type)
+            print(str("error with config file, unknown token_type : %s" % token_type))
             sys.exit(-1)
     except:
-        print "Authentification is probably wrong"
-        print "check password file"
-        print "password should only contain alpha-numerics"
+        print("Authentification is probably wrong")
+        print("check password file")
+        print("password should only contain alpha-numerics")
         sys.exit(-1)
 os.remove('token.json')
 
@@ -268,10 +273,10 @@ if options.orbitNumber != None:
 
 
 query = "%s/%s/api/collections/%s/search.json?" % (
-    config["serveur"], config["resto"], options.collection)+urllib.urlencode(dict_query)
-print query
+    config["serveur"], config["resto"], options.collection)+urlencode(dict_query)
+print(query)
 search_catalog = 'curl -k %s -o search.json "%s"' % (curl_proxy, query)
-print search_catalog
+print(search_catalog)
 os.system(search_catalog)
 time.sleep(5)
 
@@ -292,15 +297,15 @@ try:
         prodDate = data["features"][i]["properties"]["productionDate"]
         pubDate = data["features"][i]["properties"]["published"]
         print ('------------------------------------------------------')
-        print prod, feature_id
-        print "cloudCover:", cloudCover
-        print "acq date", acqDate[0:14], "prod date", prodDate[0:14], "pub date", pubDate[0:14]
+        print(prod, feature_id)
+        print("cloudCover:", cloudCover)
+        print("acq date", acqDate[0:14], "prod date", prodDate[0:14], "pub date", pubDate[0:14])
 
         if options.write_dir == None:
             options.write_dir = os.getcwd()
         file_exists = os.path.exists("%s/%s.zip" % (options.write_dir, prod))
         rac_file = '_'.join(prod.split('_')[0: -1])
-        print(">>>>>>>", rac_file)
+        print((">>>>>>>", rac_file))
         fic_unzip = glob.glob("%s/%s*" % (options.write_dir, rac_file))
         if len(fic_unzip) > 0:
             unzip_exists = True
@@ -309,7 +314,7 @@ try:
         tmpfile = "%s/%s.tmp" % (options.write_dir, prod)
         get_product = 'curl %s -o "%s" -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia' % (
             curl_proxy, tmpfile, token, config["serveur"], config["resto"], options.collection, feature_id)
-        print get_product
+        print(get_product)
         if not(options.no_download) and not(file_exists) and not(unzip_exists):
             # download only if cloudCover below maxcloud
             if cloudCover <= options.maxcloud:
@@ -320,20 +325,20 @@ try:
                 with open(tmpfile) as f_tmp:
                     try:
                         tmp_data = json.load(f_tmp)
-                        print "Result is a text file"
-                        print tmp_data
+                        print("Result is a text file")
+                        print(tmp_data)
                         sys.exit(-1)
                     except ValueError:
                         pass
 
                 os.rename("%s" % tmpfile, "%s/%s.zip" % (options.write_dir, prod))
-                print "product saved as : %s/%s.zip" % (options.write_dir, prod)
+                print("product saved as : %s/%s.zip" % (options.write_dir, prod))
             else:
-                print "cloud cover too high : %s" % (cloudCover)
+                print("cloud cover too high : %s" % (cloudCover))
         elif file_exists:
-            print "%s already exists" % prod
+            print("%s already exists" % prod)
         elif options.no_download:
-            print "no download (-n) option was chosen"
+            print("no download (-n) option was chosen")
 
 except KeyError:
-    print ">>>no product corresponds to selection criteria"
+    print(">>>no product corresponds to selection criteria")

--- a/theia_download.py
+++ b/theia_download.py
@@ -63,7 +63,7 @@ if len(sys.argv) == 1:
           sys.argv[0])
     print("example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[
         0])
-    print("example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31" % sys.argv[
+    print("example 5 : python %s -l 'Toulouse' -a config.cfg -c SPOTWORLDHERITAGE -p SPOT4 -d 2005-12-01 -f 2006-12-31" % sys.argv[
         0])
     print("example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
     print("example 7 : python %s -s 'KHUMBU' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
@@ -82,7 +82,7 @@ else:
     parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
                       help="Path where the products should be downloaded", default='.')
     parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
-                      help="Collection within theia collections", choices=['Landsat', 'Landsat57', 'SpotWorldHeritage', 'SWH1', 'LANDSAT', 'SENTINEL2', 'Snow', 'VENUS'], default='SENTINEL2')
+                      help="Collection within theia collections", choices=['Landsat', 'Landsat57', 'SPOTWORLDHERITAGE', 'SWH1', 'LANDSAT', 'SENTINEL2', 'Snow', 'VENUS'], default='SENTINEL2')
     parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
                       help="Do not download products, just print curl command", default=False)
     parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",

--- a/theia_download.py
+++ b/theia_download.py
@@ -51,7 +51,7 @@ if len(sys.argv) == 1:
     print '      '+sys.argv[0]+' [options]'
     print "     Aide : ", prog, " --help"
     print "        ou : ", prog, " -h"
-    print "example 1 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31" % sys.argv[0]
+    print "example 1 : python %s -t 'T31TFJ' -a config.cfg -d 2018-07-01 -f 2018-07-31" % sys.argv[0]
     print "example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A" % sys.argv[0]
     print "example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[0]
     print "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[

--- a/theia_download.py
+++ b/theia_download.py
@@ -164,7 +164,7 @@ if config_error:
 #=====================
 curl_proxy = ""
 if "proxy" in config.keys():
-    curl_proxy = str("-x %s --proxy-user %s:%s" % (config["proxy"],config["login_proxy"],config["password_proxy"]))
+    curl_proxy = str('-x %s --proxy-user "%s:%s"' % (config["proxy"],config["login_proxy"],config["password_proxy"]))
 
 
 
@@ -196,6 +196,8 @@ with open('token.json') as data_file:
             sys.exit(-1)
     except :
         print "Authentification is probably wrong"
+        print "check password file"
+        print "password should only contain alpha-numerics"
         sys.exit(-1)
 os.remove('token.json')
 

--- a/theia_download.py
+++ b/theia_download.py
@@ -2,287 +2,297 @@
 # -*- coding: iso-8859-1 -*-
 import json
 import time
-import os, os.path, optparse,sys
+import os
+import os.path
+import optparse
+import sys
 from datetime import date
 import urllib
 
 ###########################################################################
+
+
 class OptionParser (optparse.OptionParser):
 
-    def check_required (self, opt):
-      option = self.get_option(opt)
+    def check_required(self, opt):
+        option = self.get_option(opt)
 
-      # Assumes the option's 'default' is set to None!
-      if getattr(self.values, option.dest) is None:
-          self.error("%s option not supplied" % option)
+        # Assumes the option's 'default' is set to None!
+        if getattr(self.values, option.dest) is None:
+            self.error("%s option not supplied" % option)
 
 ###########################################################################
 
-#==================
-#parse command line
-#==================
+
+# ==================
+# parse command line
+# ==================
 if len(sys.argv) == 1:
     prog = os.path.basename(sys.argv[0])
     print '      '+sys.argv[0]+' [options]'
     print "     Aide : ", prog, " --help"
     print "        ou : ", prog, " -h"
-    print "example 1 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31"%sys.argv[0]
-    print "example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A"%sys.argv[0]
-    print "example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
-    print "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
-    print "example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31"%sys.argv[0]
-    print "example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01"%sys.argv[0]
-    
+    print "example 1 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31" % sys.argv[0]
+    print "example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A" % sys.argv[0]
+    print "example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[0]
+    print "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[
+        0]
+    print "example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31" % sys.argv[
+        0]
+    print "example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0]
+
     sys.exit(-1)
-else :
+else:
     usage = "usage: %prog [options] "
     parser = OptionParser(usage=usage)
 
-    parser.add_option("-l","--location", dest="location", action="store", type="string", \
-            help="town name (pick one which is not too frequent to avoid confusions)",default=None)
-    parser.add_option("-a","--alternative_config", dest="alternative_config", action="store", type="string", \
-            help="alternative configuration file",default=None)
-    parser.add_option("-w","--write_dir", dest="write_dir", action="store",type="string",  \
-            help="Path where the products should be downloaded",default='.')
-    parser.add_option("-c","--collection", dest="collection", action="store", type="choice",  \
-                      help="Collection within theia collections",choices=['Landsat','SpotWorldHeritage','SENTINEL2','Snow','VENUS'],default='SENTINEL2')
-    parser.add_option("-n","--no_download", dest="no_download", action="store_true",  \
-            help="Do not download products, just print curl command",default=False)
-    parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string", \
-            help="start date, fmt('2015-12-22')",default=None)
-    parser.add_option("-t", "--tile",dest="tile", action="store", type="string", \
-            help="Tile number (ex: T31TCJ), Sentinel2 only",default=None)
-    parser.add_option("--lat", dest="lat", action="store", type="float", \
-            help="latitude in decimal degrees",default=None)
-    parser.add_option("--lon", dest="lon", action="store", type="float", \
-            help="longitude in decimal degrees",default=None)
-    parser.add_option("--latmin", dest="latmin", action="store", type="float", \
-            help="min latitude in decimal degrees",default=None)
-    parser.add_option("--latmax", dest="latmax", action="store", type="float", \
-            help="max latitude in decimal degrees",default=None)
-    parser.add_option("--lonmin", dest="lonmin", action="store", type="float", \
-            help="min longitude in decimal degrees",default=None)
-    parser.add_option("--lonmax", dest="lonmax", action="store", type="float", \
-            help="max longitude in decimal degrees",default=None)
-    parser.add_option("-f","--end_date", dest="end_date", action="store", type="string", \
-            help="end date, fmt('2015-12-23')",default=None)
-    parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',\
-                      choices=['LANDSAT5','LANDSAT7','LANDSAT8','SPOT1','SPOT2','SPOT3','SPOT4','SPOT5','SENTINEL2A','SENTINEL2B','VENUS'],  help='Satellite',)
-    parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',\
+    parser.add_option("-l", "--location", dest="location", action="store", type="string",
+                      help="town name (pick one which is not too frequent to avoid confusions)", default=None)
+    parser.add_option("-a", "--alternative_config", dest="alternative_config", action="store", type="string",
+                      help="alternative configuration file", default=None)
+    parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
+                      help="Path where the products should be downloaded", default='.')
+    parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
+                      help="Collection within theia collections", choices=['Landsat', 'SpotWorldHeritage', 'LANDSAT8', 'SENTINEL2', 'Snow', 'VENUS'], default='SENTINEL2')
+    parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
+                      help="Do not download products, just print curl command", default=False)
+    parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
+                      help="start date, fmt('2015-12-22')", default=None)
+    parser.add_option("-t", "--tile", dest="tile", action="store", type="string",
+                      help="Tile number (ex: T31TCJ), Sentinel2 only", default=None)
+    parser.add_option("--lat", dest="lat", action="store", type="float",
+                      help="latitude in decimal degrees", default=None)
+    parser.add_option("--lon", dest="lon", action="store", type="float",
+                      help="longitude in decimal degrees", default=None)
+    parser.add_option("--latmin", dest="latmin", action="store", type="float",
+                      help="min latitude in decimal degrees", default=None)
+    parser.add_option("--latmax", dest="latmax", action="store", type="float",
+                      help="max latitude in decimal degrees", default=None)
+    parser.add_option("--lonmin", dest="lonmin", action="store", type="float",
+                      help="min longitude in decimal degrees", default=None)
+    parser.add_option("--lonmax", dest="lonmax", action="store", type="float",
+                      help="max longitude in decimal degrees", default=None)
+    parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
+                      help="end date, fmt('2015-12-23')", default=None)
+    parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',
+                      choices=['LANDSAT5', 'LANDSAT7', 'LANDSAT8', 'SPOT1', 'SPOT2', 'SPOT3', 'SPOT4', 'SPOT5', 'SENTINEL2A', 'SENTINEL2B', 'VENUS'],  help='Satellite',)
+    parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',
                       default=101,  help='Maximum cloud cover (%)')
-    parser.add_option('-o', '--orbitNumber', type='int', action='store', dest='orbitNumber',\
+    parser.add_option('-o', '--orbitNumber', type='int', action='store', dest='orbitNumber',
                       default=None, help='Orbit Number')
-    parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',\
+    parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',
                       default=None, help='Relative Orbit Number')
-    parser.add_option( '--level', type='choice', action='store', dest='level',\
-                       choices=['LEVEL2A','LEVEL3A'],  help='product level for reflectance products',default='LEVEL2A')
-
+    parser.add_option('--level', type='choice', action='store', dest='level',
+                      choices=['LEVEL2A', 'LEVEL3A'],  help='product level for reflectance products', default='LEVEL2A')
 
     (options, args) = parser.parse_args()
 
-if options.tile==None:
-    if options.location==None:
-        if options.lat==None or options.lon==None:
-            if options.latmin==None or options.lonmin==None or options.latmax==None or options.lonmax==None:
+if options.tile == None:
+    if options.location == None:
+        if options.lat == None or options.lon == None:
+            if options.latmin == None or options.lonmin == None or options.latmax == None or options.lonmax == None:
                 print "provide at least a point or  rectangle"
                 sys.exit(-1)
             else:
-                geom='rectangle'
+                geom = 'rectangle'
         else:
-            if options.latmin==None and options.lonmin==None and options.latmax==None and options.lonmax==None:
-                geom='point'
+            if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None:
+                geom = 'point'
             else:
                 print "please choose between point and rectangle, but not both"
                 sys.exit(-1)
 
-    else :
-        if options.latmin==None and options.lonmin==None and options.latmax==None and options.lonmax==None and options.lat==None or options.lon==None:
-            geom='location'
-        else :
+    else:
+        if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None and options.lat == None or options.lon == None:
+            geom = 'location'
+        else:
             print "please choose location and coordinates, but not both"
             sys.exit(-1)
-else :
-    if (options.tile.startswith('T') and len(options.tile)==6):
-        location=options.tile
-        geom='tile'
-    elif (not(options.tile.startswith('T')) and len(options.tile)==5):
-        location='T'+options.tile
+else:
+    if (options.tile.startswith('T') and len(options.tile) == 6):
+        location = options.tile
+        geom = 'tile'
+    elif (not(options.tile.startswith('T')) and len(options.tile) == 5):
+        location = 'T'+options.tile
     else:
         print 'tile number much gave this format : T31TFJ'
 
-if geom=='point':
-    query_geom='lat=%f\&lon=%f'%(options.lat,options.lon)
-    dict_query={'lat':options.lat,'lon':options.lon}
-elif geom=='rectangle':
-    query_geom='box={lonmin},{latmin},{lonmax},{latmax}'.format(latmin=options.latmin,latmax=options.latmax,lonmin=options.lonmin,lonmax=options.lonmax)
-    dict_query={'box':'{lonmin},{latmin},{lonmax},{latmax}'.format(latmin=options.latmin,latmax=options.latmax,lonmin=options.lonmin,lonmax=options.lonmax)}
+if geom == 'point':
+    query_geom = 'lat=%f\&lon=%f' % (options.lat, options.lon)
+    dict_query = {'lat': options.lat, 'lon': options.lon}
+elif geom == 'rectangle':
+    query_geom = 'box={lonmin},{latmin},{lonmax},{latmax}'.format(
+        latmin=options.latmin, latmax=options.latmax, lonmin=options.lonmin, lonmax=options.lonmax)
+    dict_query = {'box': '{lonmin},{latmin},{lonmax},{latmax}'.format(
+        latmin=options.latmin, latmax=options.latmax, lonmin=options.lonmin, lonmax=options.lonmax)}
 
-elif geom=='location':
-    query_geom="q=%s"%options.location
-    dict_query={'q':options.location}
-elif geom=='tile':
-    query_geom='location=%s'%options.tile
-    dict_query={'location':options.tile}
+elif geom == 'location':
+    query_geom = "q=%s" % options.location
+    dict_query = {'q': options.location}
+elif geom == 'tile':
+    query_geom = 'location=%s' % options.tile
+    dict_query = {'location': options.tile}
 
-if options.start_date!=None:
-    start_date=options.start_date
-    if options.end_date!=None:
-        end_date=options.end_date
+if options.start_date != None:
+    start_date = options.start_date
+    if options.end_date != None:
+        end_date = options.end_date
     else:
-        end_date=date.today().isoformat()
+        end_date = date.today().isoformat()
 
 
-
-#====================
+# ====================
 # read config
-#====================
+# ====================
 try:
-    config={}
-    f=file(options.alternative_config)
+    config = {}
+    f = file(options.alternative_config)
     for line in f.readlines():
-        spliteline=line.split('=',1)
+        spliteline = line.split('=', 1)
         if len(spliteline) == 2:
-            config[spliteline[0].strip()]=spliteline[1].strip()
-except :
+            config[spliteline[0].strip()] = spliteline[1].strip()
+except:
     print "error with config file opening or parsing"
     sys.exit(-2)
 
-config_error=False
-cheking_keys = ["serveur","resto","login_theia","password_theia","token_type"]
+config_error = False
+cheking_keys = ["serveur", "resto", "login_theia", "password_theia", "token_type"]
 if "proxy" in config.keys():
-    cheking_keys.extend(["login_proxy","password_proxy"])
+    cheking_keys.extend(["login_proxy", "password_proxy"])
 
 for key_name in cheking_keys:
     if key_name not in config.keys():
-        config_error=True
+        config_error = True
         print str("error with config file, missing key : %s" % key_name)
 if config_error:
     sys.exit(-2)
 
-#=====================
+# =====================
 # proxy
-#=====================
+# =====================
 curl_proxy = ""
 if "proxy" in config.keys():
-    curl_proxy = str('-x %s --proxy-user "%s:%s"' % (config["proxy"],config["login_proxy"],config["password_proxy"]))
+    curl_proxy = str('-x %s --proxy-user "%s:%s"' %
+                     (config["proxy"], config["login_proxy"], config["password_proxy"]))
 
 
-
-#============================================================
+# ============================================================
 # get a token to be allowed to bypass the authentification.
 # The token is only valid for two hours. If your connection is slow
 # or if you are downloading lots of products, it might be an issue
-#=============================================================
+# =============================================================
 
-get_token='curl -k -s -X POST %s --data-urlencode "ident=%s" --data-urlencode "pass=%s" %s/services/authenticate/>token.json'%(curl_proxy, config["login_theia"], config["password_theia"], config["serveur"])
+get_token = 'curl -k -s -X POST %s --data-urlencode "ident=%s" --data-urlencode "pass=%s" %s/services/authenticate/>token.json' % (
+    curl_proxy, config["login_theia"], config["password_theia"], config["serveur"])
 
 #print get_token
 
 os.system(get_token)
 
-token=""
-token_type=config["token_type"]
+token = ""
+token_type = config["token_type"]
 with open('token.json') as data_file:
-    try :
-	if token_type=="json":
+    try:
+        if token_type == "json":
             token_json = json.load(data_file)
-            token=token_json["access_token"]
+            token = token_json["access_token"]
 
-        elif token_type=="text":
-            token=data_file.readline()
+        elif token_type == "text":
+            token = data_file.readline()
 
         else:
             print str("error with config file, unknown token_type : %s" % token_type)
             sys.exit(-1)
-    except :
+    except:
         print "Authentification is probably wrong"
         print "check password file"
         print "password should only contain alpha-numerics"
         sys.exit(-1)
 os.remove('token.json')
 
-#====================
+# ====================
 # search catalogue
-#====================
+# ====================
 
 if os.path.exists('search.json'):
     os.remove('search.json')
 
-#query=  "%s\&platform=%s\&startDate=%s\&completionDate=%s\&maxRecords=500"\%(query_geom,options.platform,start_date,end_date)
+# query=  "%s\&platform=%s\&startDate=%s\&completionDate=%s\&maxRecords=500"\%(query_geom,options.platform,start_date,end_date)
 
-if options.platform!=None :
-    dict_query['platform']=options.platform
-dict_query['startDate']=start_date
-dict_query['completionDate']=end_date
-dict_query['maxRecords']=500
+if options.platform != None:
+    dict_query['platform'] = options.platform
+dict_query['startDate'] = start_date
+dict_query['completionDate'] = end_date
+dict_query['maxRecords'] = 500
 
-if options.collection=="SENTINEL2":
-    dict_query['processingLevel']=options.level
+if options.collection == "SENTINEL2":
+    dict_query['processingLevel'] = options.level
 
 if options.relativeOrbitNumber != None:
-    dict_query['relativeOrbitNumber']=options.relativeOrbitNumber
+    dict_query['relativeOrbitNumber'] = options.relativeOrbitNumber
 
 if options.orbitNumber != None:
-    dict_query['orbitNumber']=options.orbitNumber
+    dict_query['orbitNumber'] = options.orbitNumber
 
 
-query="%s/%s/api/collections/%s/search.json?"%(config["serveur"], config["resto"],options.collection)+urllib.urlencode(dict_query)
+query = "%s/%s/api/collections/%s/search.json?" % (
+    config["serveur"], config["resto"], options.collection)+urllib.urlencode(dict_query)
 print query
-search_catalog='curl -k %s -o search.json "%s"'%(curl_proxy,query)
+search_catalog = 'curl -k %s -o search.json "%s"' % (curl_proxy, query)
 print search_catalog
 os.system(search_catalog)
 time.sleep(5)
 
 
-#====================
+# ====================
 # Download
-#====================
+# ====================
 
 with open('search.json') as data_file:
     data = json.load(data_file)
 
-try :    
+try:
     for i in range(len(data["features"])):
-        prod=data["features"][i]["properties"]["productIdentifier"]
-        feature_id=data["features"][i]["id"]
-        cloudCover=int(data["features"][i]["properties"]["cloudCover"])
-        acqDate=data["features"][i]["properties"]["startDate"]
-        prodDate=data["features"][i]["properties"]["productionDate"]
-        pubDate=data["features"][i]["properties"]["published"]
+        prod = data["features"][i]["properties"]["productIdentifier"]
+        feature_id = data["features"][i]["id"]
+        cloudCover = int(data["features"][i]["properties"]["cloudCover"])
+        acqDate = data["features"][i]["properties"]["startDate"]
+        prodDate = data["features"][i]["properties"]["productionDate"]
+        pubDate = data["features"][i]["properties"]["published"]
 
-        print prod,feature_id
-        print "cloudCover:",cloudCover
-        print "acq date",acqDate[0:14],"prod date",prodDate[0:14],"pub date",pubDate[0:14]
+        print prod, feature_id
+        print "cloudCover:", cloudCover
+        print "acq date", acqDate[0:14], "prod date", prodDate[0:14], "pub date", pubDate[0:14]
 
-        if options.write_dir==None :
-            options.write_dir=os.getcwd()
-        file_exists=os.path.exists("%s/%s.zip"%(options.write_dir,prod))
-        tmpfile="%s/%s.tmp"%(options.write_dir,prod)
-        get_product='curl %s -o %s -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia'%(curl_proxy,tmpfile,token,config["serveur"], config["resto"],options.collection,feature_id)
+        if options.write_dir == None:
+            options.write_dir = os.getcwd()
+        file_exists = os.path.exists("%s/%s.zip" % (options.write_dir, prod))
+        tmpfile = "%s/%s.tmp" % (options.write_dir, prod)
+        get_product = 'curl %s -o %s -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia' % (
+            curl_proxy, tmpfile, token, config["serveur"], config["resto"], options.collection, feature_id)
     #    print get_product
         if not(options.no_download) and not(file_exists):
-            #download only if cloudCover below maxcloud
-            if cloudCover <=options.maxcloud:
+            # download only if cloudCover below maxcloud
+            if cloudCover <= options.maxcloud:
                 os.system(get_product)
 
-
-                #check if binary product
+                # check if binary product
 
                 with open(tmpfile) as f_tmp:
                     try:
-                        tmp_data=json.load(f_tmp)
+                        tmp_data = json.load(f_tmp)
                         print "Result is a text file"
                         print tmp_data
                         sys.exit(-1)
                     except ValueError:
                         pass
 
-                os.rename("%s"%tmpfile,"%s/%s.zip"%(options.write_dir,prod))
-                print "product saved as : %s/%s.zip"%(options.write_dir,prod)
-            else :
-                print "cloud cover too high : %s"%(cloudCover)
+                os.rename("%s" % tmpfile, "%s/%s.zip" % (options.write_dir, prod))
+                print "product saved as : %s/%s.zip" % (options.write_dir, prod)
+            else:
+                print "cloud cover too high : %s" % (cloudCover)
         elif file_exists:
-            print "%s already exists"%prod
+            print "%s already exists" % prod
         elif options.no_download:
             print "no download (-n) option was chosen"
 

--- a/theia_download.py
+++ b/theia_download.py
@@ -133,10 +133,12 @@ if options.tile == None:
             sys.exit(-1)
 else:
     if (options.tile.startswith('T') and len(options.tile) == 6):
-        location = options.tile
+        tile = options.tile
         geom = 'tile'
+
     elif (not(options.tile.startswith('T')) and len(options.tile) == 5):
-        location = 'T'+options.tile
+        tile = 'T'+options.tile
+        geom = 'tile'
     else:
         print 'tile number much gave this format : T31TFJ'
 
@@ -153,8 +155,8 @@ elif geom == 'location':
     query_geom = "q=%s" % options.location
     dict_query = {'q': options.location}
 elif geom == 'tile':
-    query_geom = 'location=%s' % options.tile
-    dict_query = {'location': options.tile}
+    query_geom = 'location=%s' % tile
+    dict_query = {'location': tile}
 elif geom == 'site':
     query_geom = 'location=%s' % options.site
     dict_query = {'location': options.site}
@@ -215,7 +217,7 @@ print("Get theia single sign on token")
 get_token = 'curl -k -s -X POST %s --data-urlencode "ident=%s" --data-urlencode "pass=%s" %s/services/authenticate/>token.json' % (
     curl_proxy, config["login_theia"], config["password_theia"], config["serveur"])
 
-#print get_token
+# print get_token
 
 os.system(get_token)
 print("Done")

--- a/theia_download.py
+++ b/theia_download.py
@@ -2,159 +2,167 @@
 # -*- coding: iso-8859-1 -*-
 import json
 import time
-import os, os.path, optparse,sys
+import os
+import os.path
+import optparse
+import sys
 from datetime import date
 import urllib
 
 ###########################################################################
+
+
 class OptionParser (optparse.OptionParser):
 
-    def check_required (self, opt):
-      option = self.get_option(opt)
+    def check_required(self, opt):
+        option = self.get_option(opt)
 
-      # Assumes the option's 'default' is set to None!
-      if getattr(self.values, option.dest) is None:
-          self.error("%s option not supplied" % option)
+        # Assumes the option's 'default' is set to None!
+        if getattr(self.values, option.dest) is None:
+            self.error("%s option not supplied" % option)
 
 ###########################################################################
 
+
 #==================
-#parse command line
+# parse command line
 #==================
 if len(sys.argv) == 1:
     prog = os.path.basename(sys.argv[0])
     print '      '+sys.argv[0]+' [options]'
     print "     Aide : ", prog, " --help"
     print "        ou : ", prog, " -h"
-    print "example 1 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31"%sys.argv[0]
-    print "example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A"%sys.argv[0]
-    print "example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
-    print "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
-    print "example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31"%sys.argv[0]
-    print "example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01"%sys.argv[0]
-    
+    print "example 1 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31" % sys.argv[0]
+    print "example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A" % sys.argv[0]
+    print "example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[0]
+    print "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[
+        0]
+    print "example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31" % sys.argv[
+        0]
+    print "example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0]
+
     sys.exit(-1)
-else :
+else:
     usage = "usage: %prog [options] "
     parser = OptionParser(usage=usage)
 
-    parser.add_option("-l","--location", dest="location", action="store", type="string", \
-            help="town name (pick one which is not too frequent to avoid confusions)",default=None)
-    parser.add_option("-a","--alternative_config", dest="alternative_config", action="store", type="string", \
-            help="alternative configuration file",default=None)
-    parser.add_option("-w","--write_dir", dest="write_dir", action="store",type="string",  \
-            help="Path where the products should be downloaded",default='.')
-    parser.add_option("-c","--collection", dest="collection", action="store", type="choice",  \
-                      help="Collection within theia collections",choices=['Landsat','SpotWorldHeritage','SENTINEL2','Snow','VENUS'],default='SENTINEL2')
-    parser.add_option("-n","--no_download", dest="no_download", action="store_true",  \
-            help="Do not download products, just print curl command",default=False)
-    parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string", \
-            help="start date, fmt('2015-12-22')",default=None)
-    parser.add_option("-t", "--tile",dest="tile", action="store", type="string", \
-            help="Tile number (ex: T31TCJ), Sentinel2 only",default=None)
-    parser.add_option("--lat", dest="lat", action="store", type="float", \
-            help="latitude in decimal degrees",default=None)
-    parser.add_option("--lon", dest="lon", action="store", type="float", \
-            help="longitude in decimal degrees",default=None)
-    parser.add_option("--latmin", dest="latmin", action="store", type="float", \
-            help="min latitude in decimal degrees",default=None)
-    parser.add_option("--latmax", dest="latmax", action="store", type="float", \
-            help="max latitude in decimal degrees",default=None)
-    parser.add_option("--lonmin", dest="lonmin", action="store", type="float", \
-            help="min longitude in decimal degrees",default=None)
-    parser.add_option("--lonmax", dest="lonmax", action="store", type="float", \
-            help="max longitude in decimal degrees",default=None)
-    parser.add_option("-f","--end_date", dest="end_date", action="store", type="string", \
-            help="end date, fmt('2015-12-23')",default=None)
-    parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',\
-                      choices=['LANDSAT5','LANDSAT7','LANDSAT8','SPOT1','SPOT2','SPOT3','SPOT4','SPOT5','SENTINEL2A','SENTINEL2B','VENUS'],  help='Satellite',)
-    parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',\
+    parser.add_option("-l", "--location", dest="location", action="store", type="string",
+                      help="town name (pick one which is not too frequent to avoid confusions)", default=None)
+    parser.add_option("-a", "--alternative_config", dest="alternative_config", action="store", type="string",
+                      help="alternative configuration file", default=None)
+    parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
+                      help="Path where the products should be downloaded", default='.')
+    parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
+                      help="Collection within theia collections", choices=['Landsat', 'SpotWorldHeritage', 'SENTINEL2', 'Snow', 'VENUS'], default='SENTINEL2')
+    parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
+                      help="Do not download products, just print curl command", default=False)
+    parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
+                      help="start date, fmt('2015-12-22')", default=None)
+    parser.add_option("-t", "--tile", dest="tile", action="store", type="string",
+                      help="Tile number (ex: T31TCJ), Sentinel2 only", default=None)
+    parser.add_option("--lat", dest="lat", action="store", type="float",
+                      help="latitude in decimal degrees", default=None)
+    parser.add_option("--lon", dest="lon", action="store", type="float",
+                      help="longitude in decimal degrees", default=None)
+    parser.add_option("--latmin", dest="latmin", action="store", type="float",
+                      help="min latitude in decimal degrees", default=None)
+    parser.add_option("--latmax", dest="latmax", action="store", type="float",
+                      help="max latitude in decimal degrees", default=None)
+    parser.add_option("--lonmin", dest="lonmin", action="store", type="float",
+                      help="min longitude in decimal degrees", default=None)
+    parser.add_option("--lonmax", dest="lonmax", action="store", type="float",
+                      help="max longitude in decimal degrees", default=None)
+    parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
+                      help="end date, fmt('2015-12-23')", default=None)
+    parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',
+                      choices=['LANDSAT5', 'LANDSAT7', 'LANDSAT8', 'SPOT1', 'SPOT2', 'SPOT3', 'SPOT4', 'SPOT5', 'SENTINEL2A', 'SENTINEL2B', 'VENUS'],  help='Satellite',)
+    parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',
                       default=101,  help='Maximum cloud cover (%)')
-    parser.add_option('-o', '--orbitNumber', type='int', action='store', dest='orbitNumber',\
+    parser.add_option('-o', '--orbitNumber', type='int', action='store', dest='orbitNumber',
                       default=None, help='Orbit Number')
-    parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',\
+    parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',
                       default=None, help='Relative Orbit Number')
-    parser.add_option( '--level', type='choice', action='store', dest='level',\
-                       choices=['LEVEL2A','LEVEL3A'],  help='product level for reflectance products',default='LEVEL2A')
-
+    parser.add_option('--level', type='choice', action='store', dest='level',
+                      choices=['LEVEL1C', 'LEVEL2A', 'LEVEL3A'],  help='product level for reflectance products', default='LEVEL2A')
 
     (options, args) = parser.parse_args()
 
-if options.tile==None:
-    if options.location==None:
-        if options.lat==None or options.lon==None:
-            if options.latmin==None or options.lonmin==None or options.latmax==None or options.lonmax==None:
+if options.tile == None:
+    if options.location == None:
+        if options.lat == None or options.lon == None:
+            if options.latmin == None or options.lonmin == None or options.latmax == None or options.lonmax == None:
                 print "provide at least a point or  rectangle"
                 sys.exit(-1)
             else:
-                geom='rectangle'
+                geom = 'rectangle'
         else:
-            if options.latmin==None and options.lonmin==None and options.latmax==None and options.lonmax==None:
-                geom='point'
+            if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None:
+                geom = 'point'
             else:
                 print "please choose between point and rectangle, but not both"
                 sys.exit(-1)
 
-    else :
-        if options.latmin==None and options.lonmin==None and options.latmax==None and options.lonmax==None and options.lat==None or options.lon==None:
-            geom='location'
-        else :
+    else:
+        if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None and options.lat == None or options.lon == None:
+            geom = 'location'
+        else:
             print "please choose location and coordinates, but not both"
             sys.exit(-1)
-else :
-    if (options.tile.startswith('T') and len(options.tile)==6):
-        location=options.tile
-        geom='tile'
-    elif (not(options.tile.startswith('T')) and len(options.tile)==5):
-        location='T'+options.tile
+else:
+    if (options.tile.startswith('T') and len(options.tile) == 6):
+        location = options.tile
+        geom = 'tile'
+    elif (not(options.tile.startswith('T')) and len(options.tile) == 5):
+        location = 'T'+options.tile
     else:
         print 'tile number much gave this format : T31TFJ'
 
-if geom=='point':
-    query_geom='lat=%f\&lon=%f'%(options.lat,options.lon)
-    dict_query={'lat':options.lat,'lon':options.lon}
-elif geom=='rectangle':
-    query_geom='box={lonmin},{latmin},{lonmax},{latmax}'.format(latmin=options.latmin,latmax=options.latmax,lonmin=options.lonmin,lonmax=options.lonmax)
-    dict_query={'box':'{lonmin},{latmin},{lonmax},{latmax}'.format(latmin=options.latmin,latmax=options.latmax,lonmin=options.lonmin,lonmax=options.lonmax)}
+if geom == 'point':
+    query_geom = 'lat=%f\&lon=%f' % (options.lat, options.lon)
+    dict_query = {'lat': options.lat, 'lon': options.lon}
+elif geom == 'rectangle':
+    query_geom = 'box={lonmin},{latmin},{lonmax},{latmax}'.format(
+        latmin=options.latmin, latmax=options.latmax, lonmin=options.lonmin, lonmax=options.lonmax)
+    dict_query = {'box': '{lonmin},{latmin},{lonmax},{latmax}'.format(
+        latmin=options.latmin, latmax=options.latmax, lonmin=options.lonmin, lonmax=options.lonmax)}
 
-elif geom=='location':
-    query_geom="q=%s"%options.location
-    dict_query={'q':options.location}
-elif geom=='tile':
-    query_geom='location=%s'%options.tile
-    dict_query={'location':options.tile}
+elif geom == 'location':
+    query_geom = "q=%s" % options.location
+    dict_query = {'q': options.location}
+elif geom == 'tile':
+    query_geom = 'location=%s' % options.tile
+    dict_query = {'location': options.tile}
 
-if options.start_date!=None:
-    start_date=options.start_date
-    if options.end_date!=None:
-        end_date=options.end_date
+if options.start_date != None:
+    start_date = options.start_date
+    if options.end_date != None:
+        end_date = options.end_date
     else:
-        end_date=date.today().isoformat()
-
+        end_date = date.today().isoformat()
 
 
 #====================
 # read config
 #====================
 try:
-    config={}
-    f=file(options.alternative_config)
+    config = {}
+    f = file(options.alternative_config)
     for line in f.readlines():
-        spliteline=line.split('=',1)
+        spliteline = line.split('=', 1)
         if len(spliteline) == 2:
-            config[spliteline[0].strip()]=spliteline[1].strip()
-except :
+            config[spliteline[0].strip()] = spliteline[1].strip()
+except:
     print "error with config file opening or parsing"
     sys.exit(-2)
 
-config_error=False
-cheking_keys = ["serveur","resto","login_theia","password_theia","token_type"]
+config_error = False
+cheking_keys = ["serveur", "resto", "login_theia", "password_theia", "token_type"]
 if "proxy" in config.keys():
-    cheking_keys.extend(["login_proxy","password_proxy"])
+    cheking_keys.extend(["login_proxy", "password_proxy"])
 
 for key_name in cheking_keys:
     if key_name not in config.keys():
-        config_error=True
+        config_error = True
         print str("error with config file, missing key : %s" % key_name)
 if config_error:
     sys.exit(-2)
@@ -164,8 +172,8 @@ if config_error:
 #=====================
 curl_proxy = ""
 if "proxy" in config.keys():
-    curl_proxy = str('-x %s --proxy-user "%s:%s"' % (config["proxy"],config["login_proxy"],config["password_proxy"]))
-
+    curl_proxy = str('-x %s --proxy-user "%s:%s"' %
+                     (config["proxy"], config["login_proxy"], config["password_proxy"]))
 
 
 #============================================================
@@ -174,27 +182,28 @@ if "proxy" in config.keys():
 # or if you are downloading lots of products, it might be an issue
 #=============================================================
 
-get_token='curl -k -s -X POST %s --data-urlencode "ident=%s" --data-urlencode "pass=%s" %s/services/authenticate/>token.json'%(curl_proxy, config["login_theia"], config["password_theia"], config["serveur"])
+get_token = 'curl -k -s -X POST %s --data-urlencode "ident=%s" --data-urlencode "pass=%s" %s/services/authenticate/>token.json' % (
+    curl_proxy, config["login_theia"], config["password_theia"], config["serveur"])
 
 #print get_token
 
 os.system(get_token)
 
-token=""
-token_type=config["token_type"]
+token = ""
+token_type = config["token_type"]
 with open('token.json') as data_file:
-    try :
-	if token_type=="json":
+    try:
+        if token_type == "json":
             token_json = json.load(data_file)
-            token=token_json["access_token"]
+            token = token_json["access_token"]
 
-        elif token_type=="text":
-            token=data_file.readline()
+        elif token_type == "text":
+            token = data_file.readline()
 
         else:
             print str("error with config file, unknown token_type : %s" % token_type)
             sys.exit(-1)
-    except :
+    except:
         print "Authentification is probably wrong"
         print "check password file"
         print "password should only contain alpha-numerics"
@@ -208,27 +217,28 @@ os.remove('token.json')
 if os.path.exists('search.json'):
     os.remove('search.json')
 
-#query=  "%s\&platform=%s\&startDate=%s\&completionDate=%s\&maxRecords=500"\%(query_geom,options.platform,start_date,end_date)
+# query=  "%s\&platform=%s\&startDate=%s\&completionDate=%s\&maxRecords=500"\%(query_geom,options.platform,start_date,end_date)
 
-if options.platform!=None :
-    dict_query['platform']=options.platform
-dict_query['startDate']=start_date
-dict_query['completionDate']=end_date
-dict_query['maxRecords']=500
+if options.platform != None:
+    dict_query['platform'] = options.platform
+dict_query['startDate'] = start_date
+dict_query['completionDate'] = end_date
+dict_query['maxRecords'] = 500
 
-if options.collection=="SENTINEL2":
-    dict_query['processingLevel']=options.level
+if options.collection == "SENTINEL2" or options.collection == "VENUS":
+    dict_query['processingLevel'] = options.level
 
 if options.relativeOrbitNumber != None:
-    dict_query['relativeOrbitNumber']=options.relativeOrbitNumber
+    dict_query['relativeOrbitNumber'] = options.relativeOrbitNumber
 
 if options.orbitNumber != None:
-    dict_query['orbitNumber']=options.orbitNumber
+    dict_query['orbitNumber'] = options.orbitNumber
 
 
-query="%s/%s/api/collections/%s/search.json?"%(config["serveur"], config["resto"],options.collection)+urllib.urlencode(dict_query)
+query = "%s/%s/api/collections/%s/search.json?" % (
+    config["serveur"], config["resto"], options.collection)+urllib.urlencode(dict_query)
 print query
-search_catalog='curl -k %s -o search.json "%s"'%(curl_proxy,query)
+search_catalog = 'curl -k %s -o search.json "%s"' % (curl_proxy, query)
 print search_catalog
 os.system(search_catalog)
 time.sleep(5)
@@ -241,48 +251,48 @@ time.sleep(5)
 with open('search.json') as data_file:
     data = json.load(data_file)
 
-try :    
+try:
     for i in range(len(data["features"])):
-        prod=data["features"][i]["properties"]["productIdentifier"]
-        feature_id=data["features"][i]["id"]
-        cloudCover=int(data["features"][i]["properties"]["cloudCover"])
-        acqDate=data["features"][i]["properties"]["startDate"]
-        prodDate=data["features"][i]["properties"]["productionDate"]
-        pubDate=data["features"][i]["properties"]["published"]
+        prod = data["features"][i]["properties"]["productIdentifier"]
+        feature_id = data["features"][i]["id"]
+        cloudCover = int(data["features"][i]["properties"]["cloudCover"])
+        acqDate = data["features"][i]["properties"]["startDate"]
+        prodDate = data["features"][i]["properties"]["productionDate"]
+        pubDate = data["features"][i]["properties"]["published"]
 
-        print prod,feature_id
-        print "cloudCover:",cloudCover
-        print "acq date",acqDate[0:14],"prod date",prodDate[0:14],"pub date",pubDate[0:14]
+        print prod, feature_id
+        print "cloudCover:", cloudCover
+        print "acq date", acqDate[0:14], "prod date", prodDate[0:14], "pub date", pubDate[0:14]
 
-        if options.write_dir==None :
-            options.write_dir=os.getcwd()
-        file_exists=os.path.exists("%s/%s.zip"%(options.write_dir,prod))
-        tmpfile="%s/%s.tmp"%(options.write_dir,prod)
-        get_product='curl %s -o %s -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia'%(curl_proxy,tmpfile,token,config["serveur"], config["resto"],options.collection,feature_id)
+        if options.write_dir == None:
+            options.write_dir = os.getcwd()
+        file_exists = os.path.exists("%s/%s.zip" % (options.write_dir, prod))
+        tmpfile = "%s/%s.tmp" % (options.write_dir, prod)
+        get_product = 'curl %s -o %s -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia' % (
+            curl_proxy, tmpfile, token, config["serveur"], config["resto"], options.collection, feature_id)
     #    print get_product
         if not(options.no_download) and not(file_exists):
-            #download only if cloudCover below maxcloud
-            if cloudCover <=options.maxcloud:
+            # download only if cloudCover below maxcloud
+            if cloudCover <= options.maxcloud:
                 os.system(get_product)
 
-
-                #check if binary product
+                # check if binary product
 
                 with open(tmpfile) as f_tmp:
                     try:
-                        tmp_data=json.load(f_tmp)
+                        tmp_data = json.load(f_tmp)
                         print "Result is a text file"
                         print tmp_data
                         sys.exit(-1)
                     except ValueError:
                         pass
 
-                os.rename("%s"%tmpfile,"%s/%s.zip"%(options.write_dir,prod))
-                print "product saved as : %s/%s.zip"%(options.write_dir,prod)
-            else :
-                print "cloud cover too high : %s"%(cloudCover)
+                os.rename("%s" % tmpfile, "%s/%s.zip" % (options.write_dir, prod))
+                print "product saved as : %s/%s.zip" % (options.write_dir, prod)
+            else:
+                print "cloud cover too high : %s" % (cloudCover)
         elif file_exists:
-            print "%s already exists"%prod
+            print "%s already exists" % prod
         elif options.no_download:
             print "no download (-n) option was chosen"
 

--- a/theia_download.py
+++ b/theia_download.py
@@ -183,13 +183,17 @@ if options.start_date != None:
 # read config
 # ====================
 
-config = {}
-f = open(options.alternative_config)
-for line in f.readlines():
-    spliteline = line.split('=', 1)
-    if len(spliteline) == 2:
-        config[spliteline[0].strip()] = spliteline[1].strip()
-
+try:
+    config = {}
+    f = open(options.alternative_config)
+    for line in f.readlines():
+        spliteline = line.split('=', 1)
+        if len(spliteline) == 2:
+            config[spliteline[0].strip()] = spliteline[1].strip()
+except IOError as e:
+    print("error with config file opening or parsing")
+    print(e)
+    sys.exit(-2)
 
 config_error = False
 cheking_keys = ["serveur", "resto", "login_theia", "password_theia", "token_type"]

--- a/theia_download.py
+++ b/theia_download.py
@@ -196,7 +196,11 @@ if options.start_date is not None:
 
 try:
     config = {}
-    f = open(options.alternative_config)
+    if options.alternative_config is not None:
+        f = open(options.alternative_config)
+    else:
+        f = open("config_theia.cfg")
+
     for line in f.readlines():
         spliteline = line.split('=', 1)
         if len(spliteline) == 2:

--- a/theia_download.py
+++ b/theia_download.py
@@ -6,7 +6,7 @@ import os
 import os.path
 import optparse
 import sys
-from datetime import date
+from datetime import date, datetime
 import urllib
 
 ###########################################################################
@@ -20,6 +20,24 @@ class OptionParser (optparse.OptionParser):
         # Assumes the option's 'default' is set to None!
         if getattr(self.values, option.dest) is None:
             self.error("%s option not supplied" % option)
+
+###########################################################################
+
+
+def checkDate(date_string):
+
+    d = date_string.split('-')
+    try:
+        year = d[0]
+        month = d[1]
+        day = d[2]
+        dd = datetime(int(year), int(month), int(day))
+    except ValueError:
+        print "Please use a valid date"
+        sys.exit(-1)
+    except IndexError:
+        print "Please use yyyy-mm-dd format for dates"
+        sys.exit(-1)
 
 ###########################################################################
 
@@ -134,8 +152,10 @@ elif geom == 'tile':
 
 if options.start_date != None:
     start_date = options.start_date
+    checkDate(start_date)
     if options.end_date != None:
         end_date = options.end_date
+        checkDate(end_date)
     else:
         end_date = date.today().isoformat()
 

--- a/theia_download.py
+++ b/theia_download.py
@@ -82,7 +82,7 @@ else:
     parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
                       help="Path where the products should be downloaded", default='.')
     parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
-                      help="Collection within theia collections", choices=['Landsat', 'SpotWorldHeritage', 'LANDSAT', 'SENTINEL2', 'Snow', 'VENUS'], default='SENTINEL2')
+                      help="Collection within theia collections", choices=['Landsat', 'Landsat57', 'SpotWorldHeritage', 'SWH1', 'LANDSAT', 'SENTINEL2', 'Snow', 'VENUS'], default='SENTINEL2')
     parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
                       help="Do not download products, just print curl command", default=False)
     parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
@@ -296,7 +296,11 @@ try:
     for i in range(len(data["features"])):
         prod = data["features"][i]["properties"]["productIdentifier"]
         feature_id = data["features"][i]["id"]
-        cloudCover = int(data["features"][i]["properties"]["cloudCover"])
+        cloudtemp = data["features"][i]["properties"]["cloudCover"]
+        if cloudtemp != None:
+            cloudCover = int(cloudtemp)
+        else:
+            cloudCover = 0
         acqDate = data["features"][i]["properties"]["startDate"]
         prodDate = data["features"][i]["properties"]["productionDate"]
         pubDate = data["features"][i]["properties"]["published"]

--- a/theia_download.py
+++ b/theia_download.py
@@ -233,44 +233,50 @@ time.sleep(5)
 with open('search.json') as data_file:
     data = json.load(data_file)
 
-for i in range(len(data["features"])):
-    prod=data["features"][i]["properties"]["productIdentifier"]
-    feature_id=data["features"][i]["id"]
+try :    
+    for i in range(len(data["features"])):
+        prod=data["features"][i]["properties"]["productIdentifier"]
+        feature_id=data["features"][i]["id"]
+        cloudCover=int(data["features"][i]["properties"]["cloudCover"])
+        acqDate=data["features"][i]["properties"]["startDate"]
+        prodDate=data["features"][i]["properties"]["productionDate"]
+        pubDate=data["features"][i]["properties"]["published"]
 
-    cloudCover=int(data["features"][i]["properties"]["cloudCover"])
-    print prod,feature_id
-    print "cloudCover:",cloudCover
+        print prod,feature_id
+        print "cloudCover:",cloudCover
+        print "acq date",acqDate[0:14],"prod date",prodDate[0:14],"pub date",pubDate[0:14]
 
-    if options.write_dir==None :
-        options.write_dir=os.getcwd()
-    file_exists=os.path.exists("%s/%s.zip"%(options.write_dir,prod))
-    tmpfile="%s/%s.tmp"%(options.write_dir,prod)
-    get_product='curl %s -o %s -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia'%(curl_proxy,tmpfile,token,config["serveur"], config["resto"],options.collection,feature_id)
-#    print get_product
-    if not(options.no_download) and not(file_exists):
-        #download only if cloudCover below maxcloud
-        if cloudCover <=options.maxcloud:
-            os.system(get_product)
+        if options.write_dir==None :
+            options.write_dir=os.getcwd()
+        file_exists=os.path.exists("%s/%s.zip"%(options.write_dir,prod))
+        tmpfile="%s/%s.tmp"%(options.write_dir,prod)
+        get_product='curl %s -o %s -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia'%(curl_proxy,tmpfile,token,config["serveur"], config["resto"],options.collection,feature_id)
+    #    print get_product
+        if not(options.no_download) and not(file_exists):
+            #download only if cloudCover below maxcloud
+            if cloudCover <=options.maxcloud:
+                os.system(get_product)
 
 
-            #check if binary product
+                #check if binary product
 
-            with open(tmpfile) as f_tmp:
-                try:
-                    tmp_data=json.load(f_tmp)
-                    print "Result is a text file"
-                    print tmp_data
-                    sys.exit(-1)
-                except ValueError:
-                    pass
+                with open(tmpfile) as f_tmp:
+                    try:
+                        tmp_data=json.load(f_tmp)
+                        print "Result is a text file"
+                        print tmp_data
+                        sys.exit(-1)
+                    except ValueError:
+                        pass
 
-            os.rename("%s"%tmpfile,"%s/%s.zip"%(options.write_dir,prod))
-            print "product saved as : %s/%s.zip"%(options.write_dir,prod)
-        else :
-            print "cloud cover too high : %s"%(cloudCover)
-    elif file_exists:
-        print "%s already exists"%prod
-    elif options.no_download:
-        print "no download (-n) option was chosen"
+                os.rename("%s"%tmpfile,"%s/%s.zip"%(options.write_dir,prod))
+                print "product saved as : %s/%s.zip"%(options.write_dir,prod)
+            else :
+                print "cloud cover too high : %s"%(cloudCover)
+        elif file_exists:
+            print "%s already exists"%prod
+        elif options.no_download:
+            print "no download (-n) option was chosen"
 
-#os.remove('search.json')
+except KeyError:
+    print ">>>no product corresponds to selection criteria"

--- a/theia_download.py
+++ b/theia_download.py
@@ -26,11 +26,12 @@ if len(sys.argv) == 1:
     print '      '+sys.argv[0]+' [options]'
     print "     Aide : ", prog, " --help"
     print "        ou : ", prog, " -h"
-    print "example 1 : python %s -l 'Toulouse' -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
-    print "example 2 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
-    print "example 3 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
-    print "example 4 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31"%sys.argv[0]
-    print "example 5 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01"%sys.argv[0]
+    print "example 1 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31"%sys.argv[0]
+    print "example 2 : python %s -l 'Toulouse' -a config.cfg -d 2018-07-01 -f 2018-07-31 --level LEVEL3A"%sys.argv[0]
+    print "example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
+    print "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31"%sys.argv[0]
+    print "example 5 : python %s -l 'Toulouse' -a config.cfg -c SpotWorldHeritage -p SPOT4 -d 2005-12-01 -f 2006-12-31"%sys.argv[0]
+    print "example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01"%sys.argv[0]
     
     sys.exit(-1)
 else :
@@ -73,6 +74,9 @@ else :
                       default=None, help='Orbit Number')
     parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',\
                       default=None, help='Relative Orbit Number')
+    parser.add_option( '--level', type='choice', action='store', dest='level',\
+                       choices=['LEVEL2A','LEVEL3A'],  help='product level for reflectance products',default='LEVEL2A')
+
 
     (options, args) = parser.parse_args()
 
@@ -210,6 +214,8 @@ dict_query['startDate']=start_date
 dict_query['completionDate']=end_date
 dict_query['maxRecords']=500
 
+if options.collection=="SENTINEL2":
+    dict_query['processingLevel']=options.level
 
 if options.relativeOrbitNumber != None:
     dict_query['relativeOrbitNumber']=options.relativeOrbitNumber

--- a/theia_download.py
+++ b/theia_download.py
@@ -82,7 +82,7 @@ else:
     parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
                       help="Path where the products should be downloaded", default='.')
     parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
-                      help="Collection within theia collections", choices=['Landsat', 'Landsat57', 'SPOTWORLDHERITAGE', 'SWH1', 'LANDSAT', 'SENTINEL2', 'Snow', 'VENUS'], default='SENTINEL2')
+                      help="Collection within theia collections", choices=['Landsat', 'Landsat57', 'SPOTWORLDHERITAGE', 'SWH1', 'LANDSAT', 'SENTINEL2', 'Snow', 'VENUS', 'VENUSVM05'], default='SENTINEL2')
     parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
                       help="Do not download products, just print curl command", default=False)
     parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
@@ -104,7 +104,7 @@ else:
     parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
                       help="end date, fmt('2015-12-23')", default=None)
     parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',
-                      choices=['LANDSAT5', 'LANDSAT7', 'LANDSAT8', 'SPOT1', 'SPOT2', 'SPOT3', 'SPOT4', 'SPOT5', 'SENTINEL2A', 'SENTINEL2B', 'VENUS'],  help='Satellite',)
+                      choices=['LANDSAT5', 'LANDSAT7', 'LANDSAT8', 'SPOT1', 'SPOT2', 'SPOT3', 'SPOT4', 'SPOT5', 'SENTINEL2A', 'SENTINEL2B', 'VENUS', 'VENUSVM05'],  help='Satellite',)
     parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',
                       default=101,  help='Maximum cloud cover (%)')
     parser.add_option('-o', '--orbitNumber', type='int', action='store', dest='orbitNumber',
@@ -266,7 +266,7 @@ dict_query['completionDate'] = end_date
 dict_query['maxRecords'] = 500
 
 
-if options.collection == "SENTINEL2" or options.collection == "VENUS":
+if options.collection == "SENTINEL2" or options.collection == "VENUS" or options.collection == "VENUSVM05":
     dict_query['processingLevel'] = options.level
 
 if options.relativeOrbitNumber != None:

--- a/theia_download.py
+++ b/theia_download.py
@@ -68,6 +68,7 @@ if len(sys.argv) == 1:
     print("example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
     print("example 7 : python %s -s 'KHUMBU' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
     print("example 8 : python %s -l 'France' -c LANDSAT -a config.cfg -d 2018-01-01" % sys.argv[0])
+    print("example 9 : python %s -t T31TGK -a config.cfg -c Snow -d 2015-01-01 --snow_level L3B-SNOW" % sys.argv[0])
     sys.exit(-1)
 else:
     usage = "usage: %prog [options] "
@@ -76,7 +77,7 @@ else:
     parser.add_option("-l", "--location", dest="location", action="store", type="string",
                       help="town name (pick one which is not too frequent to avoid confusions)", default=None)
     parser.add_option("-s", "--site", dest="site", action="store", type="string",
-                      help="Venµs Site name", default=None)
+                      help="VenÂµs Site name", default=None)
     parser.add_option("-a", "--alternative_config", dest="alternative_config", action="store", type="string",
                       help="alternative configuration file", default=None)
     parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
@@ -113,6 +114,8 @@ else:
                       default=None, help='Relative Orbit Number')
     parser.add_option('--level', type='choice', action='store', dest='level',
                       choices=['LEVEL1C', 'LEVEL2A', 'LEVEL3A'],  help='product level for reflectance products', default='LEVEL2A')
+    parser.add_option('--snow_level', type='choice', action='store', dest='snow_level',
+                      choices=['L2B-SNOW', 'L3B-SNOW'],  help='product level for snow products', default='L2B-SNOW')
     (options, args) = parser.parse_args()
 
 if options.tile == None:
@@ -268,6 +271,9 @@ dict_query['maxRecords'] = 500
 
 if options.collection == "SENTINEL2" or options.collection == "VENUS":
     dict_query['processingLevel'] = options.level
+
+if options.collection == "Snow":
+    dict_query['processingLevel'] = options.snow_level
 
 if options.relativeOrbitNumber != None:
     dict_query['relativeOrbitNumber'] = options.relativeOrbitNumber

--- a/theia_download.py
+++ b/theia_download.py
@@ -8,6 +8,7 @@ import os.path
 import optparse
 import sys
 from datetime import date, datetime
+
 if sys.version_info[0] == 2:
     from urllib import urlencode
 elif sys.version_info[0] > 2:
@@ -17,7 +18,7 @@ elif sys.version_info[0] > 2:
 ###########################################################################
 
 
-class OptionParser (optparse.OptionParser):
+class OptionParser(optparse.OptionParser):
 
     def check_required(self, opt):
         option = self.get_option(opt)
@@ -26,11 +27,11 @@ class OptionParser (optparse.OptionParser):
         if getattr(self.values, option.dest) is None:
             self.error("%s option not supplied" % option)
 
+
 ###########################################################################
 
 
 def checkDate(date_string):
-
     d = date_string.split('-')
     try:
         year = d[0]
@@ -44,6 +45,7 @@ def checkDate(date_string):
         print("Please use yyyy-mm-dd format for dates")
         sys.exit(-1)
 
+
 ###########################################################################
 
 
@@ -52,7 +54,7 @@ def checkDate(date_string):
 # ==================
 if len(sys.argv) == 1:
     prog = os.path.basename(sys.argv[0])
-    print('      '+sys.argv[0]+' [options]')
+    print('      ' + sys.argv[0] + ' [options]')
     print("     Aide : ", prog, " --help")
     print("        ou : ", prog, " -h")
     print("example 1 : python %s -t 'T31TFJ' -a config.cfg -d 2018-07-01 -f 2018-07-31" %
@@ -61,10 +63,14 @@ if len(sys.argv) == 1:
           sys.argv[0])
     print("example 3 : python %s --lon 1 --lat 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" %
           sys.argv[0])
-    print("example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" % sys.argv[
-        0])
-    print("example 5 : python %s -l 'Toulouse' -a config.cfg -c SPOTWORLDHERITAGE -p SPOT4 -d 2005-12-01 -f 2006-12-31" % sys.argv[
-        0])
+    print(
+        "example 4 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a config.cfg -d 2015-12-01 -f 2015-12-31" %
+        sys.argv[
+            0])
+    print(
+        "example 5 : python %s -l 'Toulouse' -a config.cfg -c SPOTWORLDHERITAGE -p SPOT4 -d 2005-12-01 -f 2006-12-31" %
+        sys.argv[
+            0])
     print("example 6 : python %s -l 'France' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
     print("example 7 : python %s -s 'KHUMBU' -c VENUS -a config.cfg -d 2018-01-01" % sys.argv[0])
     print("example 8 : python %s -l 'France' -c LANDSAT -a config.cfg -d 2018-01-01" % sys.argv[0])
@@ -83,7 +89,9 @@ else:
     parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
                       help="Path where the products should be downloaded", default='.')
     parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
-                      help="Collection within theia collections", choices=['Landsat', 'Landsat57', 'SPOTWORLDHERITAGE', 'SWH1', 'LANDSAT', 'SENTINEL2', 'Snow', 'VENUS', 'VENUSVM05'], default='SENTINEL2')
+                      help="Collection within theia collections",
+                      choices=['Landsat', 'Landsat57', 'SPOTWORLDHERITAGE', 'SWH1', 'LANDSAT', 'SENTINEL2', 'Snow',
+                               'VENUS', 'VENUSVM05'], default='SENTINEL2')
     parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
                       help="Do not download products, just print curl command", default=False)
     parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
@@ -105,38 +113,40 @@ else:
     parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
                       help="end date, fmt('2015-12-23')", default=None)
     parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',
-                      choices=['LANDSAT5', 'LANDSAT7', 'LANDSAT8', 'SPOT1', 'SPOT2', 'SPOT3', 'SPOT4', 'SPOT5', 'SENTINEL2A', 'SENTINEL2B', 'VENUS', 'VENUSVM05'],  help='Satellite',)
+                      choices=['LANDSAT5', 'LANDSAT7', 'LANDSAT8', 'SPOT1', 'SPOT2', 'SPOT3', 'SPOT4', 'SPOT5',
+                               'SENTINEL2A', 'SENTINEL2B', 'VENUS', 'VENUSVM05'], help='Satellite', )
     parser.add_option('-m', '--maxcloud', type='int', action='store', dest='maxcloud',
-                      default=101,  help='Maximum cloud cover (%)')
+                      default=101, help='Maximum cloud cover (%)')
     parser.add_option('-o', '--orbitNumber', type='int', action='store', dest='orbitNumber',
                       default=None, help='Orbit Number')
     parser.add_option('-r', '--relativeOrbitNumber', type='int', action='store', dest='relativeOrbitNumber',
                       default=None, help='Relative Orbit Number')
     parser.add_option('--level', type='choice', action='store', dest='level',
-                      choices=['LEVEL1C', 'LEVEL2A', 'LEVEL3A'],  help='product level for reflectance products', default='LEVEL2A')
+                      choices=['LEVEL1C', 'LEVEL2A', 'LEVEL3A'], help='product level for reflectance products',
+                      default='LEVEL2A')
     parser.add_option('--snow_level', type='choice', action='store', dest='snow_level',
-                      choices=['L2B-SNOW', 'L3B-SNOW'],  help='product level for snow products', default='L2B-SNOW')
+                      choices=['L2B-SNOW', 'L3B-SNOW'], help='product level for snow products', default='L2B-SNOW')
     (options, args) = parser.parse_args()
 
-if options.tile == None:
-    if options.location == None and options.site == None:
-        if options.lat == None or options.lon == None:
-            if options.latmin == None or options.lonmin == None or options.latmax == None or options.lonmax == None:
+if options.tile is None:
+    if options.location is None and options.site is None:
+        if options.lat is None or options.lon is None:
+            if options.latmin is None or options.lonmin is None or options.latmax is None or options.lonmax is None:
                 print("provide at least a point or  rectangle")
                 sys.exit(-1)
             else:
                 geom = 'rectangle'
         else:
-            if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None:
+            if options.latmin is None and options.lonmin is None and options.latmax is None and options.lonmax is None:
                 geom = 'point'
             else:
                 print("please choose between point and rectangle, but not both")
                 sys.exit(-1)
     else:
-        if options.latmin == None and options.lonmin == None and options.latmax == None and options.lonmax == None and options.lat == None or options.lon == None:
-            if options.location != None:
+        if options.latmin is None and options.lonmin is None and options.latmax is None and options.lonmax is None and options.lat is None or options.lon is None:
+            if options.location is not None:
                 geom = 'location'
-            elif options.site != None:
+            elif options.site is not None:
                 geom = 'site'
         else:
             print("please choose location/site or coordinates, but not both")
@@ -146,8 +156,8 @@ else:
         tile = options.tile
         geom = 'tile'
 
-    elif (not(options.tile.startswith('T')) and len(options.tile) == 5):
-        tile = 'T'+options.tile
+    elif (not (options.tile.startswith('T')) and len(options.tile) == 5):
+        tile = 'T' + options.tile
         geom = 'tile'
     else:
         print('tile number much gave this format : T31TFJ')
@@ -171,16 +181,14 @@ elif geom == 'site':
     query_geom = 'location=%s' % options.site
     dict_query = {'location': options.site}
 
-
-if options.start_date != None:
+if options.start_date is not None:
     start_date = options.start_date
     checkDate(start_date)
-    if options.end_date != None:
+    if options.end_date is not None:
         end_date = options.end_date
         checkDate(end_date)
     else:
         end_date = date.today().isoformat()
-
 
 # ====================
 # read config
@@ -217,7 +225,6 @@ curl_proxy = ""
 if "proxy" in list(config.keys()):
     curl_proxy = str('-x %s --proxy-user "%s:%s"' %
                      (config["proxy"], config["login_proxy"], config["password_proxy"]))
-
 
 # ============================================================
 # get a token to be allowed to bypass the authentification.
@@ -262,12 +269,11 @@ if os.path.exists('search.json'):
 
 # query=  "%s\&platform=%s\&startDate=%s\&completionDate=%s\&maxRecords=500"\%(query_geom,options.platform,start_date,end_date)
 
-if options.platform != None:
+if options.platform is not None:
     dict_query['platform'] = options.platform
 dict_query['startDate'] = start_date
 dict_query['completionDate'] = end_date
 dict_query['maxRecords'] = 500
-
 
 if options.collection == "SENTINEL2" or options.collection == "VENUS" or options.collection == "VENUSVM05":
     dict_query['processingLevel'] = options.level
@@ -275,21 +281,19 @@ if options.collection == "SENTINEL2" or options.collection == "VENUS" or options
 if options.collection == "Snow":
     dict_query['processingLevel'] = options.snow_level
 
-if options.relativeOrbitNumber != None:
+if options.relativeOrbitNumber is not None:
     dict_query['relativeOrbitNumber'] = options.relativeOrbitNumber
 
-if options.orbitNumber != None:
+if options.orbitNumber is not None:
     dict_query['orbitNumber'] = options.orbitNumber
 
-
 query = "%s/%s/api/collections/%s/search.json?" % (
-    config["serveur"], config["resto"], options.collection)+urlencode(dict_query)
+    config["serveur"], config["resto"], options.collection) + urlencode(dict_query)
 print(query)
 search_catalog = 'curl -k %s -o search.json "%s"' % (curl_proxy, query)
 print(search_catalog)
 os.system(search_catalog)
 time.sleep(5)
-
 
 # ====================
 # Download
@@ -303,19 +307,19 @@ try:
         prod = data["features"][i]["properties"]["productIdentifier"]
         feature_id = data["features"][i]["id"]
         cloudtemp = data["features"][i]["properties"]["cloudCover"]
-        if cloudtemp != None:
+        if cloudtemp is not None:
             cloudCover = int(cloudtemp)
         else:
             cloudCover = 0
         acqDate = data["features"][i]["properties"]["startDate"]
         prodDate = data["features"][i]["properties"]["productionDate"]
         pubDate = data["features"][i]["properties"]["published"]
-        print ('------------------------------------------------------')
+        print('------------------------------------------------------')
         print(prod, feature_id)
         print("cloudCover:", cloudCover)
         print("acq date", acqDate[0:14], "prod date", prodDate[0:14], "pub date", pubDate[0:14])
 
-        if options.write_dir == None:
+        if options.write_dir is None:
             options.write_dir = os.getcwd()
         file_exists = os.path.exists("%s/%s.zip" % (options.write_dir, prod))
         rac_file = '_'.join(prod.split('_')[0: -1])
@@ -329,7 +333,7 @@ try:
         get_product = 'curl %s -o "%s" -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia' % (
             curl_proxy, tmpfile, token, config["serveur"], config["resto"], options.collection, feature_id)
         print(get_product)
-        if not(options.no_download) and not(file_exists) and not(unzip_exists):
+        if not (options.no_download) and not (file_exists) and not (unzip_exists):
             # download only if cloudCover below maxcloud
             if cloudCover <= options.maxcloud:
                 os.system(get_product)


### PR DESCRIPTION
In order to download only the synthesis snow products, I added, in local in the file "theia_download.py", the platform "MULTISAT" and it worked for me : 

```
parser.add_option('-p', '--platform', type='choice', action='store', dest='platform',
                      choices=['LANDSAT5', 'LANDSAT7', 'LANDSAT8', 'SPOT1', 'SPOT2', 'SPOT3', 'SPOT4', 'SPOT5', 'SENTINEL2A', 'SENTINEL2B', 'VENUS', 'MULTISAT'],  help='Satellite',) 
```

Maybe is it possible to change the source code ? 

(I'm not used to use Github, maybe it's not the right section for my request. Let me know if I have to move my comment)