### PR TITLE
Add return code

### DIFF
--- a/config_landsat.cfg
+++ b/config_landsat.cfg
@@ -1,5 +1,5 @@
 serveur = https://theia-landsat.cnes.fr
 resto = resto
 token_type = json
-login_theia = login_theia
-password_theia = passwd_theia
+login_theia = pierrechevalierinfo@free.fr
+password_theia = GwSzw5pQAYsUjKG

--- a/config_theia.cfg
+++ b/config_theia.cfg
@@ -1,5 +1,5 @@
 serveur = https://theia.cnes.fr/atdistrib
 resto = resto2
 token_type = text
-login_theia = login_theia 
-password_theia = passwd_theia
+login_theia = pierrechevalierinfo@free.fr
+password_theia = GwSzw5pQAYsUjKG

--- a/theia_download.py
+++ b/theia_download.py
@@ -345,6 +345,8 @@ try:
                 print("product saved as : %s/%s.zip" % (options.write_dir, prod))
             else:
                 print("cloud cover too high : %s" % (cloudCover))
+        elif unzip_exists:
+            print("Unzipped %s already exists" % prod)
         elif file_exists:
             print("%s already exists" % prod)
         elif options.no_download:

--- a/theia_download.py
+++ b/theia_download.py
@@ -326,7 +326,8 @@ try:
         if not(options.no_download) and not(file_exists) and not(unzip_exists):
             # download only if cloudCover below maxcloud
             if cloudCover <= options.maxcloud:
-                os.system(get_product)
+                # Execution of get_product (curl execution), and store return code into ret variable:
+                ret = os.system(get_product)
 
                 # check if binary product
 
@@ -347,6 +348,12 @@ try:
             print("%s already exists" % prod)
         elif options.no_download:
             print("no download (-n) option was chosen")
-
+        if ret:
+            # If curl execution returned a non-zero return code (which was stored in ret variable), exit and return that code:
+            sys.exit(ret)
+        else:
+            sys.exit(0)
 except KeyError:
     print(">>>no product corresponds to selection criteria")
+    # Return a non-zero return code (although -1 may not be the most appropriate: to be adjusted):
+    sys.exit(-1)

--- a/theia_download.py
+++ b/theia_download.py
@@ -323,10 +323,11 @@ try:
         get_product = 'curl %s -o "%s" -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia' % (
             curl_proxy, tmpfile, token, config["serveur"], config["resto"], options.collection, feature_id)
         print(get_product)
+        ret = 0
         if not(options.no_download) and not(file_exists) and not(unzip_exists):
             # download only if cloudCover below maxcloud
             if cloudCover <= options.maxcloud:
-                # Execution of get_product (curl execution), and store return code into ret variable:
+                # Execution of get_product (curl execution), and store return code into ret variable (previously initialized at 0):
                 ret = os.system(get_product)
 
                 # check if binary product
@@ -348,7 +349,7 @@ try:
             print("%s already exists" % prod)
         elif options.no_download:
             print("no download (-n) option was chosen")
-        if ret:
+        if ret != 0:
             # If curl execution returned a non-zero return code (which was stored in ret variable), exit and return that code:
             sys.exit(ret)
         else:


### PR DESCRIPTION
When calling this script from a shell script, I bumped into some download errors, and some partially files were left as *tmp ; I wanted a way to check that the theia_download.py got executed fine, through an exit code.

Therefore I added a ret variable (for return) that I first initialised to 0 quite early (to avoid some errors in case the curl line wasn't executed) and I assigned the return code from the curl call to it.
Finally, if that return code is not zero (something went wrong), I exit the program with that exit code.  This way, a calling script can know that something went wrong.


Additionally, I also added a sys.exit(-1) at the very end, although the -1 may not be the best code to return.  To be discussed; I just took example from the other sys.exit() calls in the program.