### PR TITLE
Add return code 2

### DIFF
--- a/theia_download.py
+++ b/theia_download.py
@@ -292,6 +292,8 @@ time.sleep(5)
 with open('search.json') as data_file:
     data = json.load(data_file)
 
+return_code_final = 0   # For use in a scripting environment, use a return code; it will be a sum of the return codes from all curl calls.
+
 try:
     for i in range(len(data["features"])):
         prod = data["features"][i]["properties"]["productIdentifier"]
@@ -323,10 +325,12 @@ try:
         get_product = 'curl %s -o "%s" -k -H "Authorization: Bearer %s" %s/%s/collections/%s/%s/download/?issuerId=theia' % (
             curl_proxy, tmpfile, token, config["serveur"], config["resto"], options.collection, feature_id)
         print(get_product)
+        return_code = 0
         if not(options.no_download) and not(file_exists) and not(unzip_exists):
             # download only if cloudCover below maxcloud
             if cloudCover <= options.maxcloud:
-                os.system(get_product)
+                # Execution of get_product (curl execution), and store return code into return_code variable (previously initialized at 0):
+                return_code = os.system(get_product)
 
                 # check if binary product
 
@@ -343,10 +347,19 @@ try:
                 print("product saved as : %s/%s.zip" % (options.write_dir, prod))
             else:
                 print("cloud cover too high : %s" % (cloudCover))
+        elif unzip_exists:
+            print("Unzipped %s already exists" % prod)
         elif file_exists:
             print("%s already exists" % prod)
         elif options.no_download:
             print("no download (-n) option was chosen")
-
+        if return_code != 0:
+            # If curl execution returned a non-zero return code (which was stored in return_code variable), DO NOT exit and return that code, instead pile up that code upon final_return_code:
+            #sys.exit(return_code)
+            return_code_final += return_code
 except KeyError:
     print(">>>no product corresponds to selection criteria")
+    # Return a non-zero return code (although -1 may not be the most appropriate: to be adjusted):
+    sys.exit(-1)
+# Once all process is finished, returns an exit code: 0 if everything went well, a sum of all exit codes from curl calls otherwise:
+sys.exit(return_code_final)


### PR DESCRIPTION
Note: This pull request replaces the " Add return code #27" one.

When calling this script from a shell script, I bumped into some download errors, and some partially files were left as *tmp ; I wanted a way to check that the theia_download.py got executed fine, by using an exit code.

I added a return_code variable and a return_code_final variable, which I both first initialised to 0 quite early (to avoid some errors in case the curl line wasn't executed).  Every time the curl call is made, its return code is assigned to return_code variable, and return_code_final is aggregated with return_code.
If everything goes well, curl returns 0 and both variables' values stay at 0.

This concatenation makes the final return code quite undecipherable, but it is just supposed to raise something with a non-zero code for a calling script.
 
Finally, if that final return code is not zero (something went wrong), the program exits with that exit code. This way, a calling script can know that something went wrong.

Additionally, I also added a sys.exit(-1) at the very end, although the -1 may not be the best code to return. To be discussed; I just took example from the other sys.exit() calls in the program.


I also added  a print message in case the unzipped product already exists in the current directory.